### PR TITLE
rpcmethods: provide a way to query broker's clients by SHV path

### DIFF
--- a/src/rpcmethods.md
+++ b/src/rpcmethods.md
@@ -626,14 +626,15 @@ Information the broker has for the current client. This info about itself should
 be accessible to the client but using any other client ID should require access
 level *Service*.
 
-| Parameter   | Result                                                                                                                                |
-|-------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| Null \| Int | {"clientID":Int, "userName":String\|Null, "mountPoint":String\|Null, "subscriptions":[i{1:String, 2:String\|Null}, ...], ...} \| Null |
+| Parameter     | Result                                                                                                                                |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| Int \| String | {"clientID":Int, "userName":String\|Null, "mountPoint":String\|Null, "subscriptions":[i{1:String, 2:String\|Null}, ...], ...} \| Null |
 
-The parameter can be either *Null* (no parameter), and in such case the user info
-is for the current client. Or it can be *Int* and in such case info is for
-client with matching ID. The *Null* is returned in case there is no client with
-this ID.
+The parameter can be either  *Int* and in such case info for client with
+matching ID is provided. Or it can be *String* with SHV path for which client
+mounted on the given path (this includes also all subnodes of the mount point)
+is provided. The *Null* is returned in case there is no client with this ID or
+path is not mounted.
 
 The provided *Map* must have at least these fields:
 


### PR DESCRIPTION
This should provide administrators with a way to identify clients on mounted path without needing to go trough all connected clients.

Implements *Null* argument removal from https://github.com/silicon-heaven/shv-doc/issues/7

Addresses https://github.com/silicon-heaven/shv-doc/issues/10