### PR TITLE
rpcmessage: add UserIDRequired error

### DIFF
--- a/src/rpcmessage.md
+++ b/src/rpcmessage.md
@@ -129,6 +129,7 @@ Value | Name  | Description
 8  | `MethodCallException` | 
 9  | `Unknown`             | 
 10 | `LoginRequired`       | Method call without previous successful login.
+11 | `UserIDRequired`      | Method call requires UserID to be present in the request message. Send it again with UserID.
 32 | `UserCode`            | 
 
 **Examples**

--- a/src/rpcmessage.md
+++ b/src/rpcmessage.md
@@ -17,7 +17,7 @@ Attribute number | Attribute name     | Expected type  | Description
 9                | ShvPath            | String         | Path on which method will be called. 
 10               | Method             | String         | Name of called RPC method 
 11               | CallerIds          | List of Int    | Internal attribute filled by broker in request message to distinguish requests with the same request ID, but issued by different clients.  
-13               | RespCallerIds      | List of Int    | Internal attribute filled by broker in response message to enable support for multi-part messages and tunneling. <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
+13               | RespCallerIds      | List of Int    | Reserved, internal attribute filled by broker in response message to enable support for multi-part messages and tunneling. <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
 14               | Access             | String         | Access granted by broker to called `shvPath` and `method` to current user. 
 16               | UserId             | String         | ID of user calling RPC method filled in by broker.
 17               | AccessLevel        | Int            | Reserved, integer value, it will be used in next API version for chained brokers access capping  

--- a/src/rpcmethods/discovery.md
+++ b/src/rpcmethods/discovery.md
@@ -51,6 +51,7 @@ The method info in both *IMap* and *Map* must contain these fields:
     unique submit ID prevents from same request being handled multiple times
     because first execution will invalidate the submit ID and thus prevents
     re-execution.
+  * `32` (`1 << 5`) specifies that method requires ClientID to be called.
 * `"param"` for *Map* and `3` for *IMap* with *String* name of the parameter
   type as value. It can be missing or have value `null` instead of *String* if
   method takes no parameter (or `null`).

--- a/src/shv-types/shv-journal.md
+++ b/src/shv-types/shv-journal.md
@@ -1,5 +1,8 @@
 # SHV journal
 
+| ❗ This document is in DRAFT stage |
+|------------------------------------|
+
 > _ShvJournal_ =\
 > `<`
 > `>`

--- a/src/shv-types/shv-type-info.md
+++ b/src/shv-types/shv-type-info.md
@@ -1,5 +1,8 @@
 # SHV Type Info
 
+| ❗ This document is in DRAFT stage |
+|------------------------------------|
+
 > _TypeInfo_ =\
 > `<"version": 4> {`\
 > &nbsp;&nbsp;`"devicePaths"`: `{`\


### PR DESCRIPTION
This error allows explicit error to be given to caller that method call can be requested only with UserID meta field. Implementations can use this error to hide this from user and do method call request again with UserID set.