### PR TITLE
Rework signals

### DIFF
--- a/src/rpcmessage.md
+++ b/src/rpcmessage.md
@@ -9,28 +9,29 @@ There are three kinds of RPC messages defined:
 
 RPC message can have meta-data attribute defined.
 
-Attribute number | Attribute name     | Expected type  | Description
-----------------:|--------------------|----------------|------------
-1                | MetaTypeId         | Int            | Always equal to `1` in case of RPC message 
-2                | MetaTypeNameSpaceId| Int            | Always equal to `0` in case of RPC message, may be omitted.
-8                | RequestId          | Int            | Every RPC request must have unique number per client. Matching RPC response will have the same number. 
-9                | ShvPath            | String         | Path on which method will be called. 
-10               | Method             | String         | Name of called RPC method 
-11               | CallerIds          | List of Int    | Internal attribute filled by broker in request message to distinguish requests with the same request ID, but issued by different clients.  
-13               | RespCallerIds      | List of Int    | Reserved, internal attribute filled by broker in response message to enable support for multi-part messages and tunneling. <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
-14               | Access             | String         | Access granted by broker to called `shvPath` and `method` to current user. 
-16               | UserId             | String         | ID of user calling RPC method filled in by broker.
-17               | AccessLevel        | Int            | Reserved, integer value, it will be used in next API version for chained brokers access capping  
-18               | Part               | Bool           | Reserved, it will be used in next API version for multi-part messages   <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
+| Attribute number  | Attribute name       | Expected type    | Description
+| ----------------: | -------------------- | ---------------- | ------------
+| 1                 | MetaTypeId           | Int              | Always equal to `1` in case of RPC message
+| 2                 | MetaTypeNameSpaceId  | Int              | Always equal to `0` in case of RPC message, may be omitted.
+| 8                 | RequestId            | Int              | Every RPC request must have unique number per client. Matching RPC response will have the same number.
+| 9                 | ShvPath              | String           | Path on which method will be called.
+| 10                | Method/Signal        | String           | Name of called RPC method or raised signal.
+| 11                | CallerIds            | List of Int      | Internal attribute filled by broker in request message to distinguish requests with the same request ID, but issued by different clients.
+| 13                | RespCallerIds        | List of Int      | Reserved, internal attribute filled by broker in response message to enable support for multi-part messages and tunneling. <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
+| 14                | Access               | String           | Access granted by broker to called `shvPath` and `method` to current user.
+| 16                | UserId               | String           | ID of user calling RPC method filled in by broker.
+| 17                | AccessLevel          | Int              | Reserved, integer value, it will be used in next API version for chained brokers access capping
+| 18                | Part                 | Bool             | Reserved, it will be used in next API version for multi-part messages   <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
+| 19                | Source               | String           | Used for signals to store method name this signal is associated with.
 
 Second part of RPC message is `IMap` with following possible keys.
 
 
-Key | Key name | Description
----:|----------|------------
-1   | Params   | Optional method parameters, any [RpcValue](rpcvalue.md) is allowed.
-2   | Result   | Successful method call result, any [RpcValue](rpcvalue.md) is allowed.
-3   | Error    | Method call exception, see [RPC error](#rpc-error) for more details
+| Key  | Key name   | Description
+| ---: | ---------- | ------------
+| 1    | Params     | Optional method parameters, any [RpcValue](rpcvalue.md) is allowed.
+| 2    | Result     | Successful method call result, any [RpcValue](rpcvalue.md) is allowed.
+| 3    | Error      | Method call exception, see [RPC error](#rpc-error) for more details
 
 `RequestId` can be any unique number assigned by side that sends request
 initially. It is used to pair up requests with their responses. The common
@@ -57,23 +58,23 @@ send request again when you receive no response because of this.
 
 Attributes
 
-Attribute | Required | Note
-----------|----------|-----
-`MetaTypeId`   | yes | Always set to `1`
-`RequestId`    | yes |
-`ShvPath`      | yes |
-`Method`       | yes |
-`RevCallerIds` | no  | If tunneling or multi-part message is needed
-`CallerIds`    | no  | Modified or added by brokers
-`Access`       |     | Set by broker
-`AccessLevel`  | no  | Set or modified (by reducing access level) by broker
-`UserId`       | no  | Modified by brokers if present
+| Attribute      | Required   | Note
+| ----------     | ---------- | -----
+| `MetaTypeId`   | yes        | Always set to `1`
+| `RequestId`    | yes        |
+| `ShvPath`      | yes        |
+| `Method`       | yes        |
+| `RevCallerIds` | no         | If tunneling or multi-part message is needed
+| `CallerIds`    | no         | Modified or added by brokers
+| `Access`       |            | Set by broker
+| `AccessLevel`  | no         | Set or modified (by reducing access level) by broker
+| `UserId`       | no         | Modified by brokers if present
 
 Keys
 
-Key      | Required | Note
----------|----------|-----
-`Params` | no       | Any valid [RpcValue](rpcvalue.md)
+| Key       | Required   | Note
+| --------- | ---------- | -----
+| `Params`  | no         | Any valid [RpcValue](rpcvalue.md)
 
 **Examples**
 
@@ -89,48 +90,47 @@ Response to [RpcRequest](rpcrequest.md)
 
 Attributes
 
-Attribute | Required | Note
-----------|----------|-----
-`MetaTypeId`   | yes | Always set to `1`
-`RequestId`    | yes | ID of matching `RpcRequest`
-`RevCallerIds` | no  | Must be copied from `RpcRequest` if present.
-`CallerIds`    | no  | Must be copied from `RpcRequest` if present.
+| Attribute      | Required   | Note
+| ----------     | ---------- | -----
+| `MetaTypeId`   | yes        | Always set to `1`
+| `RequestId`    | yes        | ID of matching `RpcRequest`
+| `RevCallerIds` | no         | Must be copied from `RpcRequest` if present.
+| `CallerIds`    | no         | Must be copied from `RpcRequest` if present.
 
 Keys
 
-Key      | Required | Note
----------|----------|-----
-`Result` | yes      | Required in case of successful method call result, any [RpcValue](rpcvalue.md) is allowed.
-`Error`  | yes      | Required in case of method call exception, see [RPC error](#rpc-error) for more details.
+| Key       | Required   | Note
+| --------- | ---------- | -----
+| `Result`  | yes        | Required in case of successful method call result, any [RpcValue](rpcvalue.md) is allowed.
+| `Error`   | yes        | Required in case of method call exception, see [RPC error](#rpc-error) for more details.
 
 ### RPC Error
 
 RPC Error is `IMap` with following keys defined
 
-Key | Key name  | Required | Description
----:|---------- |----------|-------
-1   | `Code`    | yes      | Error code
-2   | `Message` | no       | Error message string
-3   | `Data`    | no       | Arbitrary payload, can be used for example for exception localization aditional info.
-specific and it is not defined by SHV RPC.
+| Key  | Key name   | Required   | Description
+| ---: | ---------- | ---------- | -------
+| 1    | `Code`     | yes        | Error code
+| 2    | `Message`  | no         | Error message string
+| 3    | `Data`     | no         | Arbitrary payload, can be used for example for exception localization aditional info.
 
 Error codes
 
-Value | Name  | Description
------:|-------|----------
-0  | `NoError`             | 
-1  | `InvalidRequest`      | The `RpcValue` sent is not a valid RPC Request object.
-2  | `MethodNotFound`      | The method does not exist / is not available.
-3  | `InvalidParams`       | Invalid method parameter(s).
-4  | `InternalError`       | Internal RPC error.
-5  | `ParseError`          | Invalid `ChainPack` was received.
-6  | `MethodCallTimeout`   | 
-7  | `MethodCallCancelled` | 
-8  | `MethodCallException` | 
-9  | `Unknown`             | 
-10 | `LoginRequired`       | Method call without previous successful login.
-11 | `UserIDRequired`      | Method call requires UserID to be present in the request message. Send it again with UserID.
-32 | `UserCode`            | 
+| Value  | Name                  | Description
+| -----: | -------               | ----------
+| 1      | `InvalidRequest`      | The `RpcValue` sent is not a valid RPC Request object.
+| 2      | `MethodNotFound`      | The method does not exist or is not available or not accessible with given access level.
+| 3      | `InvalidParams`       | Invalid method parameter.
+| 4      | `InternalError`       | Internal RPC error.
+| 5      | `ParseError`          | Invalid `ChainPack` was received.
+| 6      | `MethodCallTimeout`   | Method execution timed out (for example if method implementation needs more time to access some other resources), you should try call later.
+| 7      | `MethodCallCancelled` |
+| 8      | `MethodCallException` | Generic execution exception of the method.
+| 9      | `Unknown`             | Used if error failure can't be determined (use only if absolutely necessary)
+| 10     | `LoginRequired`       | Method call without previous successful login.
+| 11     | `UserIDRequired`      | Method call requires UserID to be present in the request message. Send it again with UserID.
+| 12     | `NotCallable`         | Generated when `RpcRequest` is received for signal
+| 32     | `UserCode`            |
 
 **Examples**
 
@@ -150,24 +150,30 @@ It is used mainly notify clients that some technological value had changed witho
 
 Attributes
 
-Attribute | Required | Note
-----------|----------|-----
-`MetaTypeId`   | yes | Always set to `1`
-`ShvPath`      | yes | Property path
-`Method`       | yes | Signal name, the property changes have obviously method `chng`
-`Access`       | no  | Minimal access level needed for this method. The `"rd"` is used if not specified.
-`AccessLevel`  | no  | Minimal access level needed for this method (complements `Access`).
+| Attribute     | Required   | Note
+| ----------    | ---------- | -----
+| `MetaTypeId`  | yes        | Always set to `1`
+| `ShvPath`     | yes        | Property path
+| `Signal`      | no         | Signal name (if not specified `"chng"` is assumed)
+| `Source`      | no         | The name of the method this signal is associated with (if not specified `"get"` is assumed)
+| `Access`      | no         | Minimal access level needed for this method. The `"rd"` is used if not specified.
+| `AccessLevel` | no         | Minimal access level needed for this method (complements `Access`).
 
 Keys
 
-Key      | Required | Note
----------|----------|-----
-`Params` | no       | Any valid [RpcValue](rpcvalue.md)
+| Key       | Required   | Note
+| --------- | ---------- | -----
+| `Params`  | no         | Any valid [RpcValue](rpcvalue.md)
+
+Warning: all signal names ending with `chng` (that includes `chng` and others
+such as `fchng`) are considered as property changes of the method they are
+associated with, and thus cache can use to update its state them instead of
+method call. If your method emits signals with different parameter than
+response's result then do not use signal names ending with `chng`.
 
 **Examples**
 
 Spontaneous notification about change of `status/motorMoving` property to `true`.
 ```
-<1:1,9:"shv/test/pme/849V/status/motorMoving",10:"chng">i{1:true}
+<1:1,9:"shv/test/pme/849V/status/motorMoving",10:"chng",11:"get">i{1:true}
 ```
-

--- a/src/rpcmethods/broker.md
+++ b/src/rpcmethods/broker.md
@@ -42,7 +42,7 @@ Client has always granted acces to these methods, so access is irrelevant in thi
 
 | Name        | SHV Path                    | Signature     | Flags | Access |
 |-------------|-----------------------------|---------------|-------|--------|
-| `subscribe` | `.app/broker/currentClient` | `void(param)` |       | Browse   |
+| `subscribe` | `.app/broker/currentClient` | `void(param)` |       | Browse |
 
 Adds rule that allows receiving of signals (notifications) from shv
 path. The subscription applies to all methods of given name in given path and
@@ -55,33 +55,39 @@ subscribes on given method in all accessible nodes of the broker.
 
 The parameter is *map* with:
 
+* `"signal"` wildcard pattern (rules from POSIX.2, 3.13 with exceptions that `/`
+  are not allowed) that must match the signal's name (`Signal`). It is assumed
+  to be `"*"` if not specified and thus matching all names.
+* `"source"` wildcard pattern (rules from POSIX.2, 3.13 with exceptions that `/`
+  are not allowed) that matches the signal's source (`Source`) and thus name of
+  the method this signal is associated with. It is assumed to be `"*"` if not
+  specified and thus matching all names.
+* `"paths"` wildcard pattern (rules from POSIX.2, 3.13 with added support for `**`
+  that matches multiple nodes) that must match the signal's path (`ShvPath`). It
+  is assumed to be `"**"` if not present and thus maching all nodes.
+* `"methods"` an obsolete alias for `"signal"`. It is used only if `"signal"` is
+  not provided. (OBSOLETE use `"signal"`)
 * `"method"` with optional method name (*String*) where default is `""` and
-  matches all methods.
+  matches all methods. Used only if `"signal"` or `"methods"` is not provided.
+  (OBSOLETE use `"methods"`)
 * `"path"` with optional SHV path (*String*) where default is `""` and thus
-  subscribe to all methods of given name in the tree.
-* `"methods"` that replaces `"method"` and instead of being exact name of the
-  method can be wildcard pattern (rules from POSIX.2, 3.13 with exceptions that
-  `/` are not allowed). `"method"` even if present is ignored once this field is
-  present.
-* `"paths"` that replaces `"path"` and instead of being static path it can be
-  a glob wildcard pattern (rules from POSIX.2, 3.13 with added support for `**`
-  that matches multiple nodes). `"path"` even if present is ignored once this
-  field is present.
+  subscribe to all methods of given name in the tree. Used only if `"paths"` is
+  not provided. (OBSOLETE use `"paths"`)
 
 ```
-=> <id:42, method:"subscribe", path:".app/broker/currentClient">i{1:{"methods":"chng", "paths":"**"}}
+=> <id:42, method:"subscribe", path:".app/broker/currentClient">i{1:{"signal":"chng", "paths":"**"}}
 <= <id:42>i{}
 ```
 ```
-=> <id:42, method:"subscribe", path:".app/broker/currentClient">i{1:{"methods":"chng", "paths":"test/device"}}
+=> <id:42, method:"subscribe", path:".app/broker/currentClient">i{1:{"signal":"chng", "paths":"test/device"}}
 <= <id:42>i{}
 ```
 
 ### `.app/broker/currentClient:unsubscribe`
 
-| Name          | SHV Path      | Signature    | Flags | Access |
-|---------------|---------------|--------------|-------|--------|
-| `unsubscribe` | `.app/broker/currentClient` | `ret(param)` |       | Browse   |
+| Name          | SHV Path                    | Signature    | Flags | Access |
+|---------------|-----------------------------|--------------|-------|--------|
+| `unsubscribe` | `.app/broker/currentClient` | `ret(param)` |       | Browse |
 
 Reverts an operation of `.app/broker/currentClient:subscribe`. The parameter
 must match exactly parameters used to subscribe.
@@ -94,19 +100,19 @@ It provides `true` in case subscription was removed and `false` if it couldn't
 have been found.
 
 ```
-=> <id:42, method:"unsubscribe", path:".app/broker/currentClient">i{1:{"method":"chng"}}
+=> <id:42, method:"unsubscribe", path:".app/broker/currentClient">i{1:{"signal":"chng"}}
 <= <id:42>i{2:true}
 ```
 ```
-=> <id:42, method:"unsubscribe", path:".app/broker/currentClient">i{1:{"method":"chng", "path":"invalid"}}
+=> <id:42, method:"unsubscribe", path:".app/broker/currentClient">i{1:{"signal":"chng", "paths":"invalid/**"}}
 <= <id:42>i{2:false}
 ```
 
 ### `.app/broker/currentClient:rejectNotSubscribed`
 
-| Name                  | SHV Path                | Signature    | Flags | Access |
-|-----------------------|-------------------------|--------------|-------|--------|
-| `rejectNotSubscribed` | `.app/broker/currentClient` | `ret(param)` |       | Browse   |
+| Name                  | SHV Path                    | Signature    | Flags | Access |
+|-----------------------|-----------------------------|--------------|-------|--------|
+| `rejectNotSubscribed` | `.app/broker/currentClient` | `ret(param)` |       | Browse |
 
 Unsubscribes all subscriptions matching the given method and SHV path. The
 intended use is when you receive notification that you are not interested in.
@@ -127,17 +133,17 @@ can be used when broker receives notification that is not subscribed by any of
 its current clients and that way remove any obsolete subscription down the line.
 
 ```
-=> <id:42, method:"rejectNotSubscribed", path:".app/broker/currentClient">i{1:{"method":"chng", "path":"test/device/foo"}}
+=> <id:42, method:"rejectNotSubscribed", path:".app/broker/currentClient">i{1:{"signal":"chng", "paths":"test/device/foo/**"}}
 <= <id:42>i{2:[{"method":"chng"}, {"method":"chng", "path":"test/device"}]}
-=> <id:42, method:"rejectNotSubscribed", path:".app/broker/currentClient">i{1:{"method":"chng", "path":"test/device/foo"}}
+=> <id:42, method:"rejectNotSubscribed", path:".app/broker/currentClient">i{1:{"signal":"chng", "paths":"test/device/foo/**"}}
 <= <id:42>i{2:[]}
 ```
 
 ### `.app/broker/currentClient:subscriptions`
 
-| Name            | SHV Path                | Signature   | Flags  | Access |
-|-----------------|-------------------------|-------------|--------|--------|
-| `subscriptions` | `.app/broker/currentClient` | `ret(void)` | Getter | Browse   |
+| Name            | SHV Path                    | Signature   | Flags  | Access |
+|-----------------|-----------------------------|-------------|--------|--------|
+| `subscriptions` | `.app/broker/currentClient` | `ret(void)` | Getter | Browse |
 
 This method allows you to list all existing subscriptions for the current
 client.
@@ -148,7 +154,7 @@ client.
 
 ```
 => <id:42, method:"subscriptions", path:".app/broker/currentClient">i{}
-<= <id:42>i{2:[{"method":"chng"},{"method":"chng", "path":"test/device"}]}
+<= <id:42>i{2:[{"method":"chng"},{"signal":"chng", "paths":"test/device/**", "source":"*"}]}
 ```
 
 ## Clients
@@ -160,9 +166,9 @@ network.
 
 ### `.app/broker:clientInfo`
 
-| Name         | SHV Path  | Signature    | Flags  | Access  |
-|--------------|-----------|--------------|--------|---------|
-| `clientInfo` | `.app/broker` | `ret(param)` |  | SuperService |
+| Name         | SHV Path      | Signature    | Flags | Access       |
+|--------------|---------------|--------------|-------|--------------|
+| `clientInfo` | `.app/broker` | `ret(param)` |       | SuperService |
 
 Information the broker has on the client.
 
@@ -198,9 +204,9 @@ required nor standardized at the moment.
 
 ### `.app/broker:mountedClientInfo`
 
-| Name                | SHV Path  | Signature    | Flags  | Access  |
-|---------------------|-----------|--------------|--------|---------|
-| `mountedClientInfo` | `.app/broker` | `ret(param)` |  | SuperService |
+| Name                | SHV Path      | Signature    | Flags | Access       |
+|---------------------|---------------|--------------|-------|--------------|
+| `mountedClientInfo` | `.app/broker` | `ret(param)` |       | SuperService |
 
 Information the broker has on the client that is mounted on the given SHV path.
 
@@ -231,8 +237,8 @@ The provided *Map* must contain the same fields as `.app/broker:clientInfo` does
 
 ### `.app/broker/currentClient:info`
 
-| Name   | SHV Path                | Signature   | Flags  | Access |
-|--------|-------------------------|-------------|--------|--------|
+| Name   | SHV Path                    | Signature   | Flags  | Access |
+|--------|-----------------------------|-------------|--------|--------|
 | `info` | `.app/broker/currentClient` | `ret(void)` | Getter | Browse |
 
 Access to the information broker has for the current client. The result is
@@ -254,9 +260,9 @@ users.
 
 ### `.app/broker:clients`
 
-| Name      | SHV Path  | Signature   | Flags  | Access  |
-|-----------|-----------|-------------|--------|---------|
-| `clients` | `.app/broker` | `ret(void)` |  | SuperService |
+| Name      | SHV Path      | Signature   | Flags | Access       |
+|-----------|---------------|-------------|-------|--------------|
+| `clients` | `.app/broker` | `ret(void)` |       | SuperService |
 
 This method allows you get list of all clients connected to the broker. This
 is an administration task.
@@ -279,15 +285,15 @@ connected clients.
 ```
 ### `.app/broker:mounts`
 
-| Name      | SHV Path  | Signature   | Flags  | Access  |
-|-----------|-----------|-------------|--------|---------|
-| `mounts` | `.app/broker` | `ret(void)` |  | SuperService |
+| Name     | SHV Path      | Signature   | Flags | Access       |
+|----------|---------------|-------------|-------|--------------|
+| `mounts` | `.app/broker` | `ret(void)` |       | SuperService |
 
 This method allows you get list of all mount paths of devices connected to the broker. This
 is an administration task.
 
-| Parameter | Result     |
-|-----------|------------|
+| Parameter | Result        |
+|-----------|---------------|
 | Null      | [String, ...] |
 
 The *List* of *Strings*s is provided where strings are mount paths of all currently mounted devices.
@@ -299,8 +305,8 @@ The *List* of *Strings*s is provided where strings are mount paths of all curren
 
 ### `.app/broker:disconnectClient`
 
-| Name               | SHV Path  | Signature     | Flags | Access  |
-|--------------------|-----------|---------------|-------|---------|
+| Name               | SHV Path      | Signature     | Flags | Access       |
+|--------------------|---------------|---------------|-------|--------------|
 | `disconnectClient` | `.app/broker` | `void(param)` |       | SuperService |
 
 Forces some specific client to be immediately disconnected from the SHV broker.

--- a/src/rpcmethods/property.md
+++ b/src/rpcmethods/property.md
@@ -18,12 +18,14 @@ can be considered as property node.
 |-------------|--------|
 | Null \| Int | Any    |
 
-It supports an optional Integer argument which is maximal age in milliseconds.
-This is used with caches along the way where sometimes `*:get` might be served
-from it without need to actually address the target device.
+Integer argument is maximal age in milliseconds. Value can be of any age if
+*Null* parameter is used (or omitted). The age is relevant when latest value
+must be received over some other medium (such as from Modbus) and thus every
+request would trigger a new exchange. Instead if latest exchange was withing
+specified age the value can be served from cache.
 
 ```
-=> <id:42, method:"get", path:"test/property">i{}
+=> <id:42, mtehod:"get", path:"test/property">i{}
 <= <id:42>i{2:"hello"}
 ```
 ```
@@ -57,21 +59,24 @@ reference is read-write property and real value is read-only one.
 <= <id:42>i{}
 ```
 
-## `*:chng`
+## `*:*chng`
 
-| Name   | SHV Path | Signature   | Flags  | Access |
-|--------|----------|-------------|--------|--------|
-| `chng` | Any      | `ret(void)` | Signal | Read   |
+| Name    | SHV Path | Signature   | Flags  | Source | Access |
+|---------|----------|-------------|--------|--------|--------|
+| `*chng` | Any      | `ret(void)` | Signal | `get`  | Read   |
 
 This is signal, and thus it gets emitted on its own and can't be called. It is
 used when you have desire to get info about value change without polling. Note
 that signal might not be emitted just on value change (that means old value can
 be same as the new one) and it might not be emitted on some value changes (for
-example if change was under some notification dead band level). To get latest
-value you should always use `*:get` instead of waiting on `*:chng` but if you
-receive `*:chng` then you can safe yourself a `*:get` call.
+example if change was under some notification deadband level). To get latest
+value you should always use `*:get` instead of waiting for `*:*chng` signal but
+if you receive `*:*chng` then you can save yourself a `*:get` call.
 
-The `*:chng` needs to provide the same value as `*:get` would, which is value
+The signal name can be either just `chng` or any name with that as suffix (such
+as `fchng`).
+
+The `*:*chng` needs to provide the same value as `*:get` would, which is value
 associated with the SHV path.
 
 | Value |
@@ -79,5 +84,4 @@ associated with the SHV path.
 | Any   |
 
 ```
-<= <method:"chng", path:"test/property">i{1:"Hello World"}
-```
+<= <signal:"chng", path:"test/property", source:"get">i{1:"Hello World"}


### PR DESCRIPTION
This contains changes from https://github.com/silicon-heaven/shv-doc/pull/25. Please review and merge that PR first.

Make signals hidden and directly associated with methods

This changes how we manage signals. They now can't stand alone and
instead must be associated not only with node but also with valid
method.

For compatibility reasons the original field `method` is not considered
to be `ShvName` and thus references not only method name but also signal
name. The new field `Source` was added that signals must use to
associate themself with method.

As a special handling signals names ending with `chng` were set to be
used only by methods that signal same value as they return. For that
reason the original `lschng` signal was renamed to `lsmod` (ls
modification) and associated with `ls` method. The property node's
`chng` signal is now associated with `get` and any signal ending with
`chng` is now allowed.
