### PR TITLE
Fix and extend multiple parts of the documentation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -17,6 +17,8 @@
   - [Bytes Exchange nodes](./rpcmethods/exchange.md)
   - [History](./rpcmethods/history.md)
 - [RPC transport layer](./rpctransportlayer.md)
+  - [Stream transport layers](./rpctransportlayer/stream.md)
+  - [CAN Bus](./rpctransportlayer/can.md)
 - [RPC URL](./rpcurl.md)
 - [SHV types](./shv-types.md)
   - [SHV type info](./shv-types/shv-type-info.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -25,4 +25,4 @@
 
 ---
 
-# SHV standard: 3.0
+# SHV standard: 3.0 pre-release

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Broker API](./rpcmethods/broker.md)
   - [Property nodes](./rpcmethods/property.md)
   - [File nodes](./rpcmethods/file.md)
+  - [Bytes Exchange nodes](./rpcmethods/exchange.md)
   - [History](./rpcmethods/history.md)
 - [RPC transport layer](./rpctransportlayer.md)
 - [RPC URL](./rpcurl.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Stream transport layers](./rpctransportlayer/stream.md)
   - [CAN Bus](./rpctransportlayer/can.md)
 - [RPC URL](./rpcurl.md)
+- [RPC RI](./rpcri.md)
 - [SHV types](./shv-types.md)
   - [SHV type info](./shv-types/shv-type-info.md)
   - [SHV journal](./shv-types/shv-journal.md)

--- a/src/rpcmethods/app.md
+++ b/src/rpcmethods/app.md
@@ -7,9 +7,9 @@ than just a few requests.
 
 ## `.app:shvVersionMajor`
 
-| Name              | SHV Path | Signature   | Flags  | Access |
-|-------------------|----------|-------------|--------|--------|
-| `shvVersionMajor` | `.app`   | `ret(void)` | Getter | Browse |
+| Name              | SHV Path | Flags  | Access |
+|-------------------|----------|--------|--------|
+| `shvVersionMajor` | `.app`   | Getter | Browse |
 
 This method provides information about implemented SHV standard. Major version
 number signal major changes in the standard and thus you are most likely
@@ -26,9 +26,9 @@ interested just in this number.
 
 ## `.app:shvVersionMinor`
 
-| Name              | SHV Path | Signature   | Flags  | Access |
-|-------------------|----------|-------------|--------|--------|
-| `shvVersionMinor` | `.app`   | `ret(void)` | Getter | Browse |
+| Name              | SHV Path | Flags  | Access |
+|-------------------|----------|--------|--------|
+| `shvVersionMinor` | `.app`   | Getter | Browse |
 
 This method provides information about implemented SHV standard. Minor version
 number signals new features added and thus if you wish to check for support of
@@ -45,9 +45,9 @@ these additions you can use this number.
 
 ## `.app:name`
 
-| Name   | SHV Path | Signature   | Flags  | Access |
-|--------|----------|-------------|--------|--------|
-| `name` | `.app`   | `ret(void)` | Getter | Browse |
+| Name   | SHV Path | Flags  | Access |
+|--------|----------|--------|--------|
+| `name` | `.app`   | Getter | Browse |
 
 This method must provide the name of the application, or at least the SHV
 implementation used in the application.
@@ -63,9 +63,9 @@ implementation used in the application.
 
 ## `.app:version`
 
-| Name      | SHV Path | Signature   | Flags  | Access |
-|-----------|----------|-------------|--------|--------|
-| `version` | `.app`   | `ret(void)` | Getter | Browse |
+| Name      | SHV Path | Flags  | Access |
+|-----------|----------|--------|--------|
+| `version` | `.app`   | Getter | Browse |
 
 This method must provide the application version, or at least the SHV
 implementation used in the application (must be consistent with information in
@@ -82,9 +82,9 @@ implementation used in the application (must be consistent with information in
 
 ## `.app:ping`
 
-| Name   | SHV Path | Signature    | Flags | Access |
-|--------|----------|--------------|-------|--------|
-| `ping` | `.app`   | `void(void)` |       | Browse |
+| Name   | SHV Path | Flags | Access |
+|--------|----------|-------|--------|
+| `ping` | `.app`   |       | Browse |
 
 This method should reliably do nothing and should always be successful. It is
 used to check the connection (if message can be passed to and from client) as
@@ -101,9 +101,9 @@ well as to keep connection in case of SHV Broker.
 
 ## `.app:date`
 
-| Name   | SHV Path | Signature   | Flags | Access |
-|--------|----------|-------------|-------|--------|
-| `date` | `.app`   | `ret(void)` |       | Browse |
+| Name   | SHV Path | Flags | Access |
+|--------|----------|-------|--------|
+| `date` | `.app`   |       | Browse |
 
 This is an optional method that provides access to the date and time this
 application is using (that includes time zone). Applications running on systems

--- a/src/rpcmethods/broker.md
+++ b/src/rpcmethods/broker.md
@@ -171,7 +171,8 @@ The *Map* containing at least these fields:
 
 * `"clientId"` with *Int* containing ID assigned to this client.
 * `"userName"` with *String* user name used during the login sequence. This is
-  optional because login might not be always required.
+  optional because broker can have clients it established itself and thus won't
+  perform any login.
 * `"mountPoint"` with *String* SHV path where device is mounted. This can be
   *Null* in case this is not a device.
 * `"subscriptions"` is a list of active subscriptions of this client.

--- a/src/rpcmethods/broker.md
+++ b/src/rpcmethods/broker.md
@@ -45,9 +45,9 @@ thus unsubscribe must be performed with care to not remove still needed ones.
 
 ### `.broker/currentClient:subscribe`
 
-| Name        | SHV Path                    | Signature     | Flags | Access |
-|-------------|-----------------------------|---------------|-------|--------|
-| `subscribe` | `.broker/currentClient`     | `void(param)` |       | Browse |
+| Name        | SHV Path                    | Flags | Access |
+|-------------|-----------------------------|-------|--------|
+| `subscribe` | `.broker/currentClient`     |       | Browse |
 
 Adds rule that allows receiving of signals (notifications) from shv
 path. The subscription applies to all methods of given name in given path and
@@ -93,9 +93,9 @@ such subscription.
 
 ### `.broker/currentClient:unsubscribe`
 
-| Name          | SHV Path                    | Signature    | Flags | Access |
-|---------------|-----------------------------|--------------|-------|--------|
-| `unsubscribe` | `.broker/currentClient`     | `ret(param)` |       | Browse |
+| Name          | SHV Path                    | Flags | Access |
+|---------------|-----------------------------|-------|--------|
+| `unsubscribe` | `.broker/currentClient`     |       | Browse |
 
 Reverts an operation of `.broker/currentClient:subscribe`.
 
@@ -119,9 +119,9 @@ and `false` if it couldn't have been found.
 
 ### `.broker/currentClient:subscriptions`
 
-| Name            | SHV Path                    | Signature   | Flags  | Access |
-|-----------------|-----------------------------|-------------|--------|--------|
-| `subscriptions` | `.broker/currentClient`     | `ret(void)` | Getter | Browse |
+| Name            | SHV Path                    | Flags  | Access |
+|-----------------|-----------------------------|--------|--------|
+| `subscriptions` | `.broker/currentClient`     | Getter | Browse |
 
 This method allows you to list all existing subscriptions for the current
 client.
@@ -152,9 +152,9 @@ network.
 
 ### `.broker:clientInfo`
 
-| Name         | SHV Path      | Signature    | Flags | Access       |
-|--------------|---------------|--------------|-------|--------------|
-| `clientInfo` | `.broker` | `ret(param)`     |       | SuperService |
+| Name         | SHV Path  | Flags | Access       |
+|--------------|-----------|-------|--------------|
+| `clientInfo` | `.broker` |       | SuperService |
 
 Information the broker has on the client.
 
@@ -191,9 +191,9 @@ required nor standardized at the moment.
 
 ### `.broker:mountedClientInfo`
 
-| Name                | SHV Path      | Signature    | Flags | Access       |
-|---------------------|---------------|--------------|-------|--------------|
-| `mountedClientInfo` | `.broker` | `ret(param)`     |       | SuperService |
+| Name                | SHV Path  | Flags | Access       |
+|---------------------|-----------|-------|--------------|
+| `mountedClientInfo` | `.broker` |       | SuperService |
 
 Information the broker has on the client that is mounted on the given SHV path.
 
@@ -224,9 +224,9 @@ The provided *Map* must contain the same fields as `.broker:clientInfo` does.
 
 ### `.broker/currentClient:info`
 
-| Name   | SHV Path                    | Signature   | Flags  | Access |
-|--------|-----------------------------|-------------|--------|--------|
-| `info` | `.broker/currentClient`     | `ret(void)` | Getter | Browse |
+| Name   | SHV Path                |  Flags  | Access |
+|--------|-------------------------|---------|--------|
+| `info` | `.broker/currentClient` |  Getter | Browse |
 
 Access to the information broker has for the current client. The result is
 client specific.
@@ -247,9 +247,9 @@ users.
 
 ### `.broker:clients`
 
-| Name      | SHV Path      | Signature   | Flags | Access       |
-|-----------|---------------|-------------|-------|--------------|
-| `clients` | `.broker` | `ret(void)`     |       | SuperService |
+| Name      | SHV Path  | Flags | Access       |
+|-----------|-----------|-------|--------------|
+| `clients` | `.broker` |       | SuperService |
 
 This method allows you get list of all clients connected to the broker. This
 is an administration task.
@@ -272,9 +272,9 @@ connected clients.
 ```
 ### `.broker:mounts`
 
-| Name     | SHV Path      | Signature   | Flags | Access       |
-|----------|---------------|-------------|-------|--------------|
-| `mounts` | `.broker` | `ret(void)`     |       | SuperService |
+| Name     | SHV Path  | Flags | Access       |
+|----------|-----------|-------|--------------|
+| `mounts` | `.broker` |       | SuperService |
 
 This method allows you get list of all mount paths of devices connected to the broker. This
 is an administration task.
@@ -292,9 +292,9 @@ The *List* of *Strings*s is provided where strings are mount paths of all curren
 
 ### `.broker:disconnectClient`
 
-| Name               | SHV Path      | Signature     | Flags | Access       |
-|--------------------|---------------|---------------|-------|--------------|
-| `disconnectClient` | `.broker` | `void(param)`     |       | SuperService |
+| Name               | SHV Path  | Flags | Access       |
+|--------------------|-----------|-------|--------------|
+| `disconnectClient` | `.broker` |       | SuperService |
 
 Forces some specific client to be immediately disconnected from the SHV broker.
 You need to provide client's ID as an argument. Based on the link layer client

--- a/src/rpcmethods/device.md
+++ b/src/rpcmethods/device.md
@@ -61,3 +61,39 @@ assigned to this device.
 => <id:42, method:"serialNumber", path:".device">i{}
 <= <id:42>i{2:"12590"}
 ```
+
+## `.device:uptime`
+
+| Name     | SHV Path  | Signature   | Flags  | Access |
+|----------|-----------|-------------|--------|--------|
+| `uptime` | `.device` | `ret(void)` | Getter | Read   |
+
+This provide current device's uptime in seconds. It is allowed to provide *Null*
+in case device doesn't track its uptime.
+
+| Parameter | Result       |
+|-----------|--------------|
+| Null      | UInt \| Null |
+
+```
+=> <id:42, method:"uptime", path:".device">i{}
+<= <id:42>i{2:3842}
+```
+
+## `.device:reset`
+
+| Name    | SHV Path  | Signature    | Flags | Access  |
+|---------|-----------|--------------|-------|---------|
+| `reset` | `.device` | `void(void)` |       | Command |
+
+Initiate the device's reset. This might not be implemented and in such case
+`NotImplemented` error should be provided.
+
+| Parameter | Result       |
+|-----------|--------------|
+| Null      |  Null |
+
+```
+=> <id:42, method:"reset", path:".device">i{}
+<= <id:42>i{}
+```

--- a/src/rpcmethods/device.md
+++ b/src/rpcmethods/device.md
@@ -5,7 +5,7 @@ benefical to see the difference between random application and application that
 runs in dedicated device and controls such device. This allows generic
 identification of such devices in the SHV tree.
 
-The call to `.app:ls("device")` can be used to identify application as being a
+The call to `:ls(".app")` can be used to identify application as being a
 device.
 
 ## `.device:name`

--- a/src/rpcmethods/device.md
+++ b/src/rpcmethods/device.md
@@ -10,9 +10,9 @@ device.
 
 ## `.device:name`
 
-| Name   | SHV Path      | Signature   | Flags  | Access |
-|--------|---------------|-------------|--------|--------|
-| `name` | `.device`     | `ret(void)` | Getter | Browse |
+| Name   | SHV Path      | Flags  | Access |
+|--------|---------------|--------|--------|
+| `name` | `.device`     | Getter | Browse |
 
 This method must provide the device name. This is a specific generic name of the
 device.
@@ -28,9 +28,9 @@ device.
 
 ## `.device:version`
 
-| Name      | SHV Path      | Signature   | Flags  | Access |
-|-----------|---------------|-------------|--------|--------|
-| `version` | `.device`     | `ret(void)` | Getter | Browse |
+| Name      | SHV Path      | Flags  | Access |
+|-----------|---------------|--------|--------|
+| `version` | `.device`     | Getter | Browse |
 
 This method must provide version (revision) of the device.
 
@@ -45,9 +45,9 @@ This method must provide version (revision) of the device.
 
 ## `.device:serialNumber`
 
-| Name           | SHV Path      | Signature   | Flags  | Access |
-|----------------|---------------|-------------|--------|--------|
-| `serialNumber` | `.device`     | `ret(void)` | Getter | Browse |
+| Name           | SHV Path      | Flags  | Access |
+|----------------|---------------|--------|--------|
+| `serialNumber` | `.device`     | Getter | Browse |
 
 This method can provide serial number of the device if that is something the
 device has. It is allowed to provide *Null* in case there is no serial number
@@ -64,9 +64,9 @@ assigned to this device.
 
 ## `.device:uptime`
 
-| Name     | SHV Path  | Signature   | Flags  | Access |
-|----------|-----------|-------------|--------|--------|
-| `uptime` | `.device` | `ret(void)` | Getter | Read   |
+| Name     | SHV Path  | Flags  | Access |
+|----------|-----------|--------|--------|
+| `uptime` | `.device` | Getter | Read   |
 
 This provide current device's uptime in seconds. It is allowed to provide *Null*
 in case device doesn't track its uptime.
@@ -82,9 +82,9 @@ in case device doesn't track its uptime.
 
 ## `.device:reset`
 
-| Name    | SHV Path  | Signature    | Flags | Access  |
-|---------|-----------|--------------|-------|---------|
-| `reset` | `.device` | `void(void)` |       | Command |
+| Name    | SHV Path  | Flags | Access  |
+|---------|-----------|-------|---------|
+| `reset` | `.device` |       | Command |
 
 Initiate the device's reset. This might not be implemented and in such case
 `NotImplemented` error should be provided.

--- a/src/rpcmethods/discovery.md
+++ b/src/rpcmethods/discovery.md
@@ -5,9 +5,9 @@ associated with it.
 
 ## `*:dir`
 
-| Name  | SHV Path | Signature    | Flags | Access |
-|-------|----------|--------------|-------|--------|
-| `dir` | Any      | `ret(param)` |       | Browse |
+| Name  | SHV Path | Flags | Access |
+|-------|----------|-------|--------|
+| `dir` | Any      |       | Browse |
 
 This method needs to be implemented for every node (that is every valid SHV
 path). It provides a way to list all available methods and signals of the node.
@@ -108,9 +108,9 @@ The compatibility mapping between *IMap* keys and historical *Map* is:
 
 ## `*:ls`
 
-| Name | SHV Path | Signature    | Flags | Signal  | Access |
-|------|----------|--------------|-------|---------|--------|
-| `ls` | Any      | `ret(param)` |       | `lsmod` | Browse |
+| Name | SHV Path | Flags | Signal  | Access |
+|------|----------|-------|---------|--------|
+| `ls` | Any      |       | `lsmod` | Browse |
 
 This method needs to be implemented for every valid SHV path. It provides a way
 to list all children nodes of the node.

--- a/src/rpcmethods/exchange.md
+++ b/src/rpcmethods/exchange.md
@@ -24,9 +24,9 @@ caller doesn't call `exchange` for `idleTimeOut` (in default 30 seconds).
 
 ## `*:newExchange`
 
-| Name          | SHV Path | Signature   | Flags | Access          |
-|---------------|----------|-------------|-------|-----------------|
-| `newExchange` | Any      | `ret(void)` |       | Write or higher |
+| Name          | SHV Path | Flags | Access          |
+|---------------|----------|-------|-----------------|
+| `newExchange` | Any      |       | Write or higher |
 
 This creates new connection for this bytes exchange node. The
 connections are maintained as sub-nodes of this one.
@@ -58,9 +58,9 @@ assignment should minimize the reuse of the node names as much as possible.
 
 ## `*/ASSIGNED:exchange`
 
-| Name       | SHV Path                   | Signature    | Flags | Access |
-|------------|----------------------------|--------------|-------|--------|
-| `exchange` | Bellow Bytes Exchange node | `ret(param)` |       | Write  |
+| Name       | SHV Path                   | Flags | Access |
+|------------|----------------------------|-------|--------|
+| `exchange` | Bellow Bytes Exchange node |       | Write  |
 
 This is the method that is called to exchange bytes.
 
@@ -136,9 +136,9 @@ The more realistic exchange to the one used as an example for
 
 ## `*/ASSIGNED:options`
 
-| Name      | SHV Path                   | Signature   | Flags  | Access        |
-|-----------|----------------------------|-------------|--------|---------------|
-| `options` | Bellow Bytes Exchange node | `ret(void)` | Getter | Super-service |
+| Name      | SHV Path                   | Flags  | Access        |
+|-----------|----------------------------|--------|---------------|
+| `options` | Bellow Bytes Exchange node | Getter | Super-service |
 
 This provide access to the options associated with this connection.
 
@@ -162,9 +162,9 @@ The result is Map with at least these fields:
 
 ## `*/ASSIGNED:setOptions`
 
-| Name         | SHV Path                   | Signature     | Flags  | Access        |
-|--------------|----------------------------|---------------|--------|---------------|
-| `setOptions` | Bellow Bytes Exchange node | `void(param)` | Setter | Super-service |
+| Name         | SHV Path                   | Flags  | Access        |
+|--------------|----------------------------|--------|---------------|
+| `setOptions` | Bellow Bytes Exchange node | Setter | Super-service |
 
 This allows modification of option associated with this connection. Note that
 not all options might be modifiable and only fields specified in Map are
@@ -186,9 +186,9 @@ this node must be allowed.
 
 ## `*/ASSIGNED:close`
 
-| Name    | SHV Path                   | Signature    | Flags | Access        |
-|---------|----------------------------|--------------|-------|---------------|
-| `close` | Bellow Bytes Exchange node | `void(void)` |       | Super-service |
+| Name    | SHV Path                   | Flags | Access        |
+|---------|----------------------------|-------|---------------|
+| `close` | Bellow Bytes Exchange node |       | Super-service |
 
 This method allows caller to terminate the connection.
 
@@ -208,9 +208,9 @@ this node must be allowed.
 
 ## `*/ASSIGNED:peer`
 
-| Name   | SHV Path                   | Signature   | Flags  | Access        |
-|--------|----------------------------|-------------|--------|---------------|
-| `peer` | Bellow Bytes Exchange node | `ret(void)` | Getter | Super-service |
+| Name   | SHV Path                   | Flags  | Access        |
+|--------|----------------------------|--------|---------------|
+| `peer` | Bellow Bytes Exchange node | Getter | Super-service |
 
 This provide ClientIds from `*:newExchange` that created this sub-node.
 

--- a/src/rpcmethods/exchange.md
+++ b/src/rpcmethods/exchange.md
@@ -1,0 +1,329 @@
+# Bytes Exchange node
+
+| ❗ This document is in DRAFT stage |
+|------------------------------------|
+
+SHV RPC is by design request-response communication protocol and most notably
+messages can be dropped without a retransmit nor notice and thus lost. At the
+same time there are use cases when it is desirable to emulate byte streams such
+as remote terminal. This requires improved reliability in the form of ensured
+delivery and both sides transmission control.
+
+In the RPC communication there are always two sides, the asking peer (caller)
+and the answering peer (answerer). To get the bidirectional communication we
+exchange bytes between caller and answerer with method call. This gives full
+control over the communication flow to the caller that must initiate every
+exchange. The answerer holds the connection status and notifies caller on
+status change with SVH signal, but it doesn't send any to be exchanged bytes on
+its own.
+
+The communication is initialized by requesting the new exchange point by caller
+from answerer. This exchange point is then used to exchange bytes between them.
+It is deleted either by either sides closing it by an appropriate action or if
+caller doesn't call `exchange` for `idleTimeOut` (in default 30 seconds).
+
+## `*:newExchange`
+
+| Name          | SHV Path | Signature   | Flags | Access          |
+|---------------|----------|-------------|-------|-----------------|
+| `newExchange` | Any      | `ret(void)` |       | Write or higher |
+
+This creates new connection for this bytes exchange node. The
+connections are maintained as sub-nodes of this one.
+
+The access level should be at minimum write but it might be increased depending
+on the resource this provides. For example you really do not want to provide
+access to root shell with just write access level.
+
+| Parameter | Result |
+|-----------|--------|
+| {...}     | String |
+
+The parameter is Map with options to be set to the new exchange point. The real
+options depend on the implementation. The minimum supported list is described in
+`*/ASSIGNED:options`.
+
+The result of this call is name of the created node. The names of the sub-nodes
+is up to the implementation and its algorithm for generating them but it should
+choose short names. The soft limit for the name is 8 characters which gives
+versatility for assignment for node name generation but still limits length of
+the name that clients can expect to remember. For security reasons the
+assignment should minimize the reuse of the node names as much as possible.
+
+```
+=> <id:42, method:"newExchange", path:"test/sh">i{}
+<= <signal:"lschng", path:"test/sh", source:"ls">i{1:{"a3":true}}
+<= <id:42>i{2:"a3"}
+```
+
+## `*/ASSIGNED:exchange`
+
+| Name       | SHV Path                   | Signature    | Flags | Access |
+|------------|----------------------------|--------------|-------|--------|
+| `exchange` | Bellow Bytes Exchange node | `ret(param)` |       | Write  |
+
+This is the method that is called to exchange bytes.
+
+The access level must be disregarded for this method and instead CallerIds must
+be used to control access. The message must have same CallerIds as the one for
+`*:newExchange` that created this node. Nobody else must be allowed to call this
+method (this is for consistency of exchanged bytes).
+
+| Parameter                 | Result                    |
+|---------------------------|---------------------------|
+| i{0:UInt, 1:UInt: 3:Blob} | i{1:UInt, 2:UInt, 3:Blob} |
+
+The parameter is IMap with following items:
+
+| Key | Name           | Type | Description                                                                                                                                                                    |
+|-----|----------------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0   | Counter        | UInt | The counter for exchanges. This counts from 0 to 63 and wraps back to zero. It is used to detect multiple call attempts in case response got lost. This field must be present. |
+| 1   | ReadyToReceive | UInt | Number of bytes caller is ready to receive in the response. The default if not specified is `0`.                                                                               |
+| 3   | Data           | Blob | Bytes from caller. It doesn't have to be present if no data is being send.                                                                                                     |
+
+The result is IMap with following items:
+
+| Key | Name           | Type | Description                                                                                           |
+|-----|----------------|------|-------------------------------------------------------------------------------------------------------|
+| 1   | ReadyToReceive | UInt | Number of bytes answerer is ready to receive in the next exchange. The default if not present is `0`. |
+| 2   | ReadyToSend    | UInt | Number of bytes answerer is ready to send in the next exchange. The default if not present is `0`.    |
+| 3   | Data           | Blob | Bytes from answerer. It doesn't have to be present if no data is being send.                          |
+
+Note that ReadyToSend is only informative. The implementation of answerer might
+not know number of available bytes and this most likely it will use only `0` for
+"no bytes available" and `1` for "some bytes available". The parameter's
+ReadyToReceive thus should always contain maximum number of bytes caller is
+willing to receive and not copy of ReadyToSend from previous result or signal.
+
+```
+=> <id:42, method:"exchange", path:"test/sh/a3">i{0:7, 1:32, 3:b"Foo"}
+<= <id:42>i{2:i{1:24, 3:b"Hello Foo\n"}}
+```
+
+## `*/ASSIGNED:exchange:ready`
+
+The caller is expected to call `*/ASSIGNED:exchange` as soon as it can again to
+send and/or receive more data, but in some cases it might want to just wait for
+data to become available or space available for receive. In such a situation
+caller must poll `*/ASSIGNED:exchange` periodically to detect that, but that
+introduces a time delay. The solution is that answerer sends this signal when
+either ReadyToReceive or ReadyToSend goes from zero to non-zero value. The
+caller still must poll the exchange method to not get stuck in case signal gets
+lost but in most cases this signal will speed up the return to the data
+exchanging again.
+
+| Value             |
+|-------------------|
+| i{1:UInt, 2:UInt} |
+
+The value is IMap with items ReadyToReceive and ReadyToSend from
+`*/ASSIGNED:exchange` result.
+
+```
+<= <signal:"ready", path:"test/sh/a3", source:"exchange">i{1:i{1:1}}
+```
+
+The more realistic exchange to the one used as an example for
+`*/ASSIGNED:exchange` would contain this signal in the following way:
+
+```
+=> <id:42, method:"exchange", path:"test/sh/a3">i{0:7, 1:32, 3:b"Foo"}
+<= <id:42>i{2:i{1:24}}
+<= <signal:"ready", path:"test/sh/a3", source:"exchange">i{1:i{1:32, 2:1}}
+=> <id:43, method:"exchange", path:"test/sh/a3">i{0:8, 1:32}
+<= <id:43>i{2:i{1:32, 3:b"Hello Foo\n"}}
+```
+
+## `*/ASSIGNED:options`
+
+| Name      | SHV Path                   | Signature   | Flags  | Access        |
+|-----------|----------------------------|-------------|--------|---------------|
+| `options` | Bellow Bytes Exchange node | `ret(void)` | Getter | Super-service |
+
+This provide access to the options associated with this connection.
+
+The access level applies only to the callers that do not match CallerIds.
+Request messages with CallerIds matching that for `*:newExchange` that created
+this node must be allowed.
+
+| Parameter | Result |
+|-----------|--------|
+| Null      | {...}  |
+
+The result is Map with at least these fields:
+
+* `idleTimeOut` with unsigned integer with number of seconds. It allows client
+  to specify its own idle time out. If not specified the 30 seconds are used.
+
+```
+=> <id:42, method:"options", path:"test/sh/a3">i{}
+<= <id:42>i{2:{"idleTimeOut":30}}
+```
+
+## `*/ASSIGNED:setOptions`
+
+| Name         | SHV Path                   | Signature     | Flags  | Access        |
+|--------------|----------------------------|---------------|--------|---------------|
+| `setOptions` | Bellow Bytes Exchange node | `void(param)` | Setter | Super-service |
+
+This allows modification of option associated with this connection. Note that
+not all options might be modifiable and only fields specified in Map are
+modified (the rest is kept same or derived from new options based on the
+implementation).
+
+The access level applies only to the callers that do not match CallerIds.
+Request messages with CallerIds matching that for `*:newExchange` that created
+this node must be allowed.
+
+| Parameter | Result |
+|-----------|--------|
+| {...}      | Null  |
+
+```
+=> <id:42, method:"setOptions", path:"test/sh/a3">i{1:{"idleTimeOut":60}}
+<= <id:42>i{}
+```
+
+## `*/ASSIGNED:close`
+
+| Name    | SHV Path                   | Signature    | Flags | Access        |
+|---------|----------------------------|--------------|-------|---------------|
+| `close` | Bellow Bytes Exchange node | `void(void)` |       | Super-service |
+
+This method allows caller to terminate the connection.
+
+The access level applies only to the callers that do not match CallerIds.
+Request messages with CallerIds matching that for `*:newExchange` that created
+this node must be allowed.
+
+| Parameter | Result |
+|-----------|--------|
+| Null      | Null   |
+
+```
+=> <id:42, method:"close", path:"test/sh/a3">i{}
+<= <signal:"lschng", path:"test/sh", source:"ls">i{1:{"a3":false}}
+<= <id:42>i{}
+```
+
+## `*/ASSIGNED:peer`
+
+| Name   | SHV Path                   | Signature   | Flags  | Access        |
+|--------|----------------------------|-------------|--------|---------------|
+| `peer` | Bellow Bytes Exchange node | `ret(void)` | Getter | Super-service |
+
+This provide ClientIds from `*:newExchange` that created this sub-node.
+
+This method contrary to others of this node uses normal access level control and
+thus only clients with Super-service access level can call it.
+
+| Parameter | Result     |
+|-----------|------------|
+| Null      | [Int, ...] |
+
+The result is List of Ints.
+
+```
+=> <id:42, method:"peer", path:"test/sh/a3">i{}
+<= <id:42>i{2:[30,1,2]]}
+```
+
+
+## Walkthrough of the caller
+
+The first step is to initiate the new connection by calling `*:newExchange`.
+This will provide you with sub-node name that you will be using from now on
+(instead of `ASSIGNED`).
+
+The next step is to subscribe for the notifications for this node (The
+expectation is that there is a RPC Broker in between. You can skip this step if
+that is not the case). You want to use full path to the assigned node, source
+`exchange` and all of signal `ready`.
+
+Based on the usage you might want to inspect and tweak exchange options with
+`*/ASSIGNED:options` and `*/ASSIGNED:setOptions` respectively.
+
+The initial exchange should not contain any data and is intended only to query
+for exchange state, but it is allowed to specify that it is ready to receive
+non-zero amount of bytes. This allows answerer to send data even on initial
+exchange.
+
+The subsequent exchanges must contain only number of bytes the latest exchange
+or `ready` signal specified as being free (the latest information applies).
+
+It is highly suggested to prioritize data retrieval because it is possible that
+more data can't be received by answerer unless you take some data out and thus
+you might wait for non-zero ReadyToReceive indefinitely.
+
+You also must maintain exchanges (even dummy ones that do not transfer any data)
+in reasonable intervals to ensure that connection is not closed due to
+inactivity (suggestion is the half interval of `idleTimeOut`).
+
+The connection can be terminated by calling `*/ASSIGNED:close`. The answerer can
+terminate connection for what ever reason on its own. It will send `*:ls:lschng`
+signal with but in general caller detects termination by receiving
+`MethodNotFound` error when calling `*/ASSIGNED:exchange` method. There is no
+way to report disconnect reason.
+
+
+## Walkthrough of the answerer
+
+The connection gets initiated by caller with `*:newExchange` method. Answerer
+must allocate sub-node for it. Based on the intended usage the resource needed
+for bytes exchanging can be initiated (such as spawning process or opening the
+serial device) or it can be postponed to the first bytes exchange.
+
+The data received on exchange will be processed (commonly just pushed to buffer)
+and response will be created with data from processing. The sent data must be
+kept until next exchange alongside with received Counter value to send same data
+if Counter of the next exchange is the same. The received data from exchange
+that has matching Counter with previous one are disregarded and not processed
+(they are repeat of what was already received).
+
+The number of bytes ready that can be received is provided to the caller as well
+as number of bytes that could be still provided. The signal `ready` must be
+emitted if one of these parameters changes from zero to non-zero because caller
+might not attempt next exchange for some time if they are set to zero.
+
+The idle time between exchanges is measured and if there was no exchange for
+longer than `idleTimeOut` seconds then node is discarded and thus subsequent
+calls for data exchange will result into an error `MethodNotFound`. The same
+happens if `*/ASSIGNED:close` method is called.
+
+
+## Design remarks
+
+These are few points you should be aware when you are using Bytes Exchange
+nodes:
+
+* The access to the node is controlled by path of message in SHV network. This
+  path is in general constant during the connection, but there are cases when it
+  can change without client being notified about it (when intermediate RPC
+  Broker resets) and this will result into two issues:
+
+  * Existing connections will be inaccessible (resulting into `MethodNotFound`
+    errors)
+  * Existing connection could be suddenly accessible by some other client. The
+    exploit of this would require pretty significant setup but still is
+    possible.
+
+* The reason for every connection being its own sub-node instead of method
+  parameter is to allow filtering signals for a different connections and
+  callers.
+
+* The usage for `ready` signal is to signal only readiness when exchange wasn't
+  previously ready. It should not intentionally be emitted if previous exchange
+  specified no ability to receive or no ability to send bytes. This is to only
+  fasten caller's detection of readiness when it is reasonable to just be quiet
+  and keep answerer to work.
+
+* The possibility of lost messages is covered by counter. This provides a way to
+  easily get data even when messages are being randomly lost by attempting call
+  again and again with same counter value. In case of caller these multiple call
+  attempts are intuitive (they must contain same content) but answerer must
+  ensure the following to keep data consistent:
+
+  * Sent data are kept until next exchange to allow their re-transmit if counter
+    isn't changed.
+  * Received data are used only when counter changes, not when it stays the
+    same.

--- a/src/rpcmethods/file.md
+++ b/src/rpcmethods/file.md
@@ -13,6 +13,18 @@ method definition in this standard). That is because sometimes you want to allow
 a different levels of access to different users to same file (such as append to
 regular user, while write and truncate to super users).
 
+The combination of provided method for file node will define the expected
+functionality of the file. For the convinience of reader the following table is
+provided with various, but not all, types of file node modes. The methods
+`*:stat`, and `*:size` are always provided.
+
+|             | `*:crc` / `*:sha1` | `*:read` | `*:write` | `*:truncate` | `*:append` |
+|-------------|--------------------|----------|-----------|--------------|------------|
+| Read only   | ✔️                  | ✔️        | ❌        | ❌           | ❌         |
+| Fixed size  | ✔️                  | ✔️        | ✔️         | ❌           | ❌         |
+| Resizable   | ✔️                  | ✔️        | ✔️         | ✔️            | ✔️          |
+| Append only | ✔️                  | ✔️        | ❌        | ❌           | ✔️          |
+
 ## `*:stat`
 
 | Name   | SHV Path | Flags  | Access |
@@ -167,7 +179,7 @@ zero length bytes value is provided.
 | `write` | Any      |       | Write  |
 
 Write is optional method that can be provided if modification of the file over
-SHV RCP is allowed.
+SHV RPC is allowed.
 
 | Parameter    | Result |
 |--------------|--------|

--- a/src/rpcmethods/file.md
+++ b/src/rpcmethods/file.md
@@ -15,9 +15,9 @@ regular user, while write and truncate to super users).
 
 ## `*:stat`
 
-| Name   | SHV Path | Signature   | Flags  | Access |
-|--------|----------|-------------|--------|--------|
-| `stat` | Any      | `ret(void)` | Getter | Read   |
+| Name   | SHV Path | Flags  | Access |
+|--------|----------|--------|--------|
+| `stat` | Any      | Getter | Read   |
 
 This method provides information about this file. It is required for file nodes.
 
@@ -42,9 +42,9 @@ The result is IMap with these fields:
 
 ## `*:size`
 
-| Name   | SHV Path | Signature   | Flags  | Access |
-|--------|----------|-------------|--------|--------|
-| `size` | Any      | `ret(void)` | Getter | Read   |
+| Name   | SHV Path | Flags  | Access |
+|--------|----------|--------|--------|
+| `size` | Any      | Getter | Read   |
 
 This provides faster access to only file size. Although it is also part of the
 `*:stat` the size of the file is commonly used to quickly identify added data to
@@ -62,9 +62,9 @@ implemented together with `*:stat`.
 
 ## `*:crc`
 
-| Name  | SHV Path | Signature    | Flags | Access |
-|-------|----------|--------------|-------|--------|
-| `crc` | Any      | `ret(param)` |       | Read   |
+| Name  | SHV Path | Flags | Access |
+|-------|----------|-------|--------|
+| `crc` | Any      |       | Read   |
 
 The validation of the data is common operation that can be done either to verify
 that all went all right or to detect that write might not be required because
@@ -104,9 +104,9 @@ with files that are growing.
 
 ## `*:sha1`
 
-| Name   | SHV Path | Signature    | Flags | Access |
-|--------|----------|--------------|-------|--------|
-| `sha1` | Any      | `ret(param)` |       | Read   |
+| Name   | SHV Path | Flags | Access |
+|--------|----------|-------|--------|
+| `sha1` | Any      |       | Read   |
 
 The basic CRC32 algorithm, that is required alongside with `*:read`, is
 serviceable but it has higher probability of result collision. If you want to
@@ -136,9 +136,9 @@ The result must always be 20 bytes long *Bytes*.
 
 ## `*:read`
 
-| Name   | SHV Path | Signature    | Flags             | Access |
-|--------|----------|--------------|-------------------|--------|
-| `read` | Any      | `ret(param)` | LARGE_RESULT_HINT | Read   |
+| Name   | SHV Path | Flags             | Access |
+|--------|----------|-------------------|--------|
+| `read` | Any      | LARGE_RESULT_HINT | Read   |
 
 Method for reading data from file. This method should be implemented only if you
 allow reading of the file.
@@ -162,9 +162,9 @@ zero length bytes value is provided.
 
 ## `*:write`
 
-| Name    | SHV Path | Signature    | Flags | Access |
-|---------|----------|--------------|-------|--------|
-| `write` | Any      | `void(param)` |       | Write  |
+| Name    | SHV Path | Flags | Access |
+|---------|----------|-------|--------|
+| `write` | Any      |       | Write  |
 
 Write is optional method that can be provided if modification of the file over
 SHV RCP is allowed.
@@ -186,9 +186,9 @@ extend file boundary if that is possible, or it can result into an error.
 
 ## `*:truncate`
 
-| Name       | SHV Path | Signature     | Flags | Access |
-|------------|----------|---------------|-------|--------|
-| `truncate` | Any      | `void(param)` |       | Write  |
+| Name       | SHV Path | Flags | Access |
+|------------|----------|-------|--------|
+| `truncate` | Any      |       | Write  |
 
 Change the file boundary. This method should be implemented if `*:write` allows
 write outside of the file boundary. It should not be present if that is not
@@ -211,9 +211,9 @@ such as only increase is allowed, or maximal size of the file.
 
 ## `*:append`
 
-| Name     | SHV Path | Signature     | Flags | Access |
-|----------|----------|---------------|-------|--------|
-| `append` | Any      | `void(param)` |       | Write  |
+| Name     | SHV Path | Flags | Access |
+|----------|----------|-------|--------|
+| `append` | Any      |       | Write  |
 
 Append is a optional special way to perform write by always appending to the end
 of the file. Append can be provided even if `*:write` is not and other way

--- a/src/rpcmethods/history.md
+++ b/src/rpcmethods/history.md
@@ -39,9 +39,9 @@ but all paths recorded (or to be recorded) in single log must be provided.
 
 ### `.history/**:getLog`
 
-| Name     | SHV Path      | Signature    | Flags           | Access |
-|----------|---------------|--------------|-----------------|--------|
-| `getLog` | `.history/**` | `ret(param)` | HintLargeResult | Browse |
+| Name     | SHV Path      | Flags           | Access |
+|----------|---------------|-----------------|--------|
+| `getLog` | `.history/**` | HintLargeResult | Browse |
 
 Queries logs for the recorded signals in given time range.
 
@@ -147,9 +147,9 @@ storage such as database or cyclic buffer.
 
 #### `.history/**/.records/*:fetch`
 
-| Name    | SHV Path                 | Signature   | Flags           | Access  |
-|---------|--------------------------|-------------|-----------------|---------|
-| `fetch` | `.history/**/.records/*` | `ret(void)` | HintLargeResult | Service |
+| Name    | SHV Path                 | Flags           | Access  |
+|---------|--------------------------|-----------------|---------|
+| `fetch` | `.history/**/.records/*` | HintLargeResult | Service |
 
 This allows you to fetch records from log.
 
@@ -201,9 +201,9 @@ Fetch that is outside of the valid record ID range must not provide error.
 
 #### `.history/**/.records/*:span`
 
-| Name   | SHV Path                 | Signature   | Flags  | Access  |
-|--------|--------------------------|-------------|--------|---------|
-| `span` | `.history/**/.records/*` | `ret(void)` | Getter | Service |
+| Name   | SHV Path                 | Flags  | Access  |
+|--------|--------------------------|--------|---------|
+| `span` | `.history/**/.records/*` | Getter | Service |
 
 This allows fetch of boundaries for the record IDs and also the keep record
 range.
@@ -278,9 +278,9 @@ The rest of the file must contain *List*s with following columns:
 
 ### `.history/**/.records/*:sync` and `.history/**/.files/*:sync`
 
-| Name       | SHV Path                                           | Signature    | Flags | Access       |
-|------------|----------------------------------------------------|--------------|-------|--------------|
-| `lastSync` | `.history/**/.records/*` or `.history/**/.files/*` | `void(void)` |       | SuperService |
+| Name       | SHV Path                                           | Flags | Access       |
+|------------|----------------------------------------------------|-------|--------------|
+| `lastSync` | `.history/**/.records/*` or `.history/**/.files/*` |       | SuperService |
 
 Trigger the synchronization manually right now.
 
@@ -296,9 +296,9 @@ already in the progress.
 
 ### `.history/**/.records/*:lastSync` and `.history/**/.files/*:lastSync`
 
-| Name       | SHV Path                                           | Signature   | Flags  | Access  |
-|------------|----------------------------------------------------|-------------|--------|---------|
-| `lastSync` | `.history/**/.records/*` or `.history/**/.files/*` | `ret(void)` | Getter | Service |
+| Name       | SHV Path                                           | Flags  | Access  |
+|------------|----------------------------------------------------|--------|---------|
+| `lastSync` | `.history/**/.records/*` or `.history/**/.files/*` | Getter | Service |
 
 This provides information when last synchronization was performed.
 

--- a/src/rpcmethods/property.md
+++ b/src/rpcmethods/property.md
@@ -4,6 +4,16 @@ Property node is a convention where we associate value storage with some SHV
 path. The value can be received, optionally modified and its change can be
 signaled.
 
+The type of the property depends on the presence of the methods. The following
+table 
+
+|                                 | `*:get` | `*:get:*chng` | `*:set` |
+|---------------------------------|---------|---------------|---------|
+| Read only                       | ✔️       | ❌            | ❌      |
+| Read only with signaled change  | ✔️       | ✔️             | ❌      |
+| Read-write                      | ✔️       | ❌            | ✔️       |
+| Read-write with signaled change | ✔️       | ✔️             | ✔️       |
+
 ## `*:get`
 
 | Name  | SHV Path | Flags  | Access |

--- a/src/rpcmethods/property.md
+++ b/src/rpcmethods/property.md
@@ -33,7 +33,7 @@ specified age the value can be served from cache.
 <= <id:42>i{2:"Cached"}
 ```
 
-### Signal `*chng`
+## `*:get:*chng`
 
 Value change can be optionally signaled with signal. It is used when you have
 desire to get info about value change without polling. Note that signal might
@@ -55,6 +55,7 @@ associated with the SHV path.
 
 ```
 <= <signal:"chng", path:"test/property", source:"get">i{1:"Hello World"}
+```
 
 
 ## `*:set`

--- a/src/rpcmethods/property.md
+++ b/src/rpcmethods/property.md
@@ -6,9 +6,9 @@ signaled.
 
 ## `*:get`
 
-| Name  | SHV Path | Signature    | Flags  | Access |
-|-------|----------|--------------|--------|--------|
-| `get` | Any      | `ret(param)` | Getter | Read   |
+| Name  | SHV Path | Flags  | Access |
+|-------|----------|--------|--------|
+| `get` | Any      | Getter | Read   |
 
 This method is used for getting the current value associated with SHV path.
 Every property node needs to have `get` method and every node with `get` method
@@ -60,9 +60,9 @@ associated with the SHV path.
 
 ## `*:set`
 
-| Name  | SHV Path | Signature     | Flags  | Access |
-|-------|----------|---------------|--------|--------|
-| `set` | Any      | `void(param)` | Setter | Write  |
+| Name  | SHV Path | Flags  | Access |
+|-------|----------|--------|--------|
+| `set` | Any      | Setter | Write  |
 
 This method is used for changing the value associated with SHV path. By
 providing this method alongside with `*:get` you are making the read-write

--- a/src/rpcri.md
+++ b/src/rpcri.md
@@ -1,0 +1,71 @@
+# SHV RPC RI
+
+This is definition of Resource Identifiers for SHV RPC. SHV has two types of
+resources; those are methods and signals. Signals are always associated with
+some method and thus Resource Identifier actually matches primarily methods
+while it can also select between different signals.
+
+Resource identifiers are human readable and are used thorough this documentation
+and they can be used by other tools.
+
+Example of Resource Identifiers for SHV RPC:
+```
+.app:name
+test/device/track/1::chng
+test/*:ls:lschng
+```
+
+Resource Identifier consists of up to triplet delimited by colon `:`. The
+following variations are allowed:
+
+```
+PATH:METHOD:SIGNAL
+PATH:METHOD
+PATH:METHOD:
+PATH::SIGNAL
+PATH
+```
+
+__The first field `PATH` is the SHV path.__ It can be glob pattern (rules from
+POSIX.2, 3.13 with added support for ``**`` that matches multiple nodes). Note
+that empty `PATH` is the root of the SHV node tree.
+
+__The second field `METHOD` is the SHV RPC method name.__ It can be wildcard
+pattern (rules from POSIX.2, 3.13). The method name can't be empty but if you
+keep it empty then it is assumed to be `get` (the most likely method to be
+paired with signals). It is assumed to be `*` if not specified at all (the
+`PATH` variation).
+
+__The third field `SIGNAL` is the SHV RPC signal name__ while `METHOD` in such
+case is its source. It can be wildcard pattern (rules from POSIX.2, 3.13). It is
+assumed to be `*` if not specified (the `PATH` and `PATH:METHOD` variant). The
+empty signal name is invalid and thus it is used to identify only method (thus
+`PATH:METHOD:` matches only method while `PATH:METHOD` matches also all of its
+signals).
+
+The following table breaks down different variations and how they are applied
+when matching either method or signal:
+
+| Variation            | Method                                        | Signal                                                      |
+|----------------------|-----------------------------------------------|-------------------------------------------------------------|
+| `PATH:METHOD:SIGNAL` | Applies if `PATH` and `METHOD` matches.       | Applies if `PATH` and `METHOD` and `SIGNAL` matches.        |
+| `PATH:METHOD`        | Applies if `PATH` and `METHOD` matches.       | Applies if `PATH` and `METHOD` matches.                     |
+| `PATH:METHOD:`       | Applies if `PATH` and `METHOD` matches.       | Never applies                                               |
+| `PATH::SIGNAL`       | Applies if `PATH` matches and method is `get` | Applies if `PATH` and `SIGNAL` matches and source is `get`. |
+| `PATH`               | Applies if `PATH` matches.                    | Applies if `PATH` matches.                                  |
+
+Notice that there is no variation that matches only signals and not its
+associated method. This is because signal is always associated with some method
+and Resource Identifier primarily identifies the method and only after that
+filter its signals if resource is signal. This means that Resource Identifier
+can't be used to filter both methods and signals from the same set of resources.
+
+The examples of different Resource Identifiers and resources:
+
+| Resource                                                         | `**` | `**:get:` | `test/**` | `test/**::*chng` |
+|------------------------------------------------------------------|------|-----------|-----------|------------------|
+| Method `name` on path `.app`                                     | ✔️    | ❌        | ❌        | ❌               |
+| Method `get` on path `sub/device/track`                          | ✔️    | ✔️         | ❌        | ❌               |
+| Method `get` on path `test/device/track`                         | ✔️    | ✔️         | ✔️         | ✔️                |
+| Signal `chng` associated with `get` on path `test/device/track`  | ✔️    | ❌        | ✔️         | ✔️                |
+| Signal `lschng` associated with `ls` on path `test/device/track` | ✔️    | ❌        | ✔️         | ❌               |

--- a/src/rpctransportlayer.md
+++ b/src/rpctransportlayer.md
@@ -36,7 +36,7 @@ It is `01 00` on stream layer or `STX 00 ETX` or `STX 00 ETX D2 02 EF 8D` (if CR
 The message must be sent before `hello` on layers without connection tracking (TTY, CAN). It might
 be optionally sent also on other layers like socket.
 
-## Stream
+## Block
 
 The communication on bidirectional stream where delivery is ensured and checked.
 The transport layer establishes and maintains point-to-point connection on its

--- a/src/rpctransportlayer.md
+++ b/src/rpctransportlayer.md
@@ -1,276 +1,36 @@
 # RPC transport layer
 
-RPC messages can be transmitted over different layers. What they have in common
-is that they transfer messages `data` in the following format:
+RPC messages can be transmitted over different layers. Any message transport
+layer that guarantees the following functionalities can be used for SHV RPC:
 
-```
-+--------+-------------+
-| Format | RPC Message |
-+--------+-------------+
-```
-
-[Format is a single byte](https://github.com/silicon-heaven/libshv/blob/353424a9b9b1943761a6a6ec50c1eb516a00877e/libshvchainpack/src/chainpack/rpc.h#L13)
-that signals the encoding of the following data:
-* `00` - ResetSession, RPC Message is not included in this case
-* `01` - Chainpack
-* `02` - Cpon (deprecated)
-* `03` - Json (deprecated)
-
-RPC Message is actual [transmitted message](rpcmessage.md).
-
-Transport layers guarantee the following functionality:
 * Messages need to be transferred completely without error or transport error
   needs to be detected.
 * Any message can be lost without transport error reporting error.
 * Communication needs to be point-to-point, or transport layer needs to emulate
   that.
+* Messages can be of any size
 
-`ResetSession` message is used to reset current session.
-Basically it works in the same manner as socket reconnection, but it can be used also on layers
-without connection tracking like serial port.
-When `ResetSession` is received, then receiver should clear all the peer state.
-`ResetSession` message can be used by client to log-out or by broker to kick-out client.
+Exchanged messages have `data` always start with a single byte identifying the
+format of the subsequent bytes in the message (if any):
 
-`ResetSession` message contains only Format part, the message is excluded. 
-It is `01 00` on stream layer or `STX 00 ETX` or `STX 00 ETX D2 02 EF 8D` (if CRC is on) on serial layer.
-The message must be sent before `hello` on layers without connection tracking (TTY, CAN). It might
-be optionally sent also on other layers like socket.
+* `00` - ResetSession
+* `01` - Chainpack encoded [RPC Message](./rpcmessage.md)
+* `02` - Cpon encoded [RpcMessage](./rpcmessage.md) (deprecated)
+* `03` - Json encoded [RpcMessage](./rpcmessage.md) (deprecated)
 
-## Block
+`ResetSession` message is used to reset current session. Basically it works in
+the same manner as socket reconnection, but it can be used also on layers
+without connection tracking like serial port. When `ResetSession` is received,
+then receiver should clear the peer's state. `ResetSession` message can be used
+by client to log-out or by broker to kick-out client. `ResetSession` message
+contains only Format part, the message is excluded. It is `01 00` on stream
+layer or `STX 00 ETX` or `STX 00 ETX D2 02 EF 8D` (if CRC is on) on serial
+layer. This message must be sent before `hello` on layers without connection
+tracking (TTY, CAN). It might be optionally sent also on other layers like
+socket.
 
-The communication on bidirectional stream where delivery is ensured and checked.
-The transport layer establishes and maintains point-to-point connection on its
-own.
+There are protocols defined for some common transport layers that do not support
+message transport layer as required by SHV RPC. This includes the following:
 
-Message is transmitted in stream as one complete segment where message length is
-sent before data. The receiving side first reads size and thus knows how much
-data it should expect to receive. Message length is encoded as Chainpack
-unsigned integer.
-
-```
-+--------+------+
-| length | data |
-+--------+------+
-```
-
-The transport error is detected if there is no byte received from other side for
-more than 5 seconds during the message transfer.
-
-Transport errors are handled by an immediate disconnect. It is expected that
-connecting side is able to reestablish connection.
-
-The primary transport layer used with this is TCP/IP, but this also applies to
-Unix sockets or pair of pipes.
-
-
-## Serial
-
-This is communication over data stream with possible on the line errors (such as
-data corruption).
-
-The message data is encapsulated in start and stop byte and on link layers
-without error checking it is also verified with CRC32. The dedicated bytes for
-this are escaped in the message data.
-
-```
-+-----+------+-----------+---------+
-| STX | data | ETX / ATX | *CRC32* |
-+-----+------+-----------+---------+
-```
-* `STX` start of message `0xA2`
-* `ETX` end of the message `0xA3`
-* `ATX` abort the message `0xA4`
-* `ESC` escape `0xAA`
-  * `STX` in data will be coded as `ESC` `0x02`
-  * `ETX` in data will be coded as `ESC` `0x03`
-  * `ATX` in data will be coded as `ESC` `0x04`
-  * `ESC` in data will be coded as `ESC` `0x0A`
-* data - escaped message data
-* CRC32 - escaped BigEndian CRC32 of `data` (same as used in IEEE 802.3 and
-  [known as plain
-  CRC-32](https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-32-iso-hdlc))
-  only on channels that do not provide data corruption prevention on its own and
-  only after `ETX` (not after `ATX`).
-
-The transport error is detected if there is no byte received from other side for
-more that 5 seconds during the message transfer or when `STX` or `ATX` is
-received before `EXT` or if `CRC32` do not match received data (on channels with
-possible corruption such as RS232 and not TCP/IP).
-
-Transport errors do not have to be handled explicitly because any subsequent
-message can still be consistent. The invalid message should be just dropped.
-
-The primary transport layer is RS232 with hardware flow control, but usage with
-other streams, such as TCP/IP or Unix domain named socket, is also possible.
-
-In some cases the restart of the connection might not be available. That is for
-example when application just doesn't have rights for it or even when such
-restart would not be propagated to the target, for what ever reason. To solve
-this the empty message is reserved (that is message `STX ETX 0x0`). Once client
-receives a valid empty message then it must drop any state it keeps for it.
-
-
-## CAN-FD (DRAFT)
-
-The communication over CAN (Control Area Network) bus. Compared to other
-transport layers that are point-to-point this is bus and thus it must not only
-provide message transfer but also a connection tracking.
-
-CAN has the following abilities:
-* Delivery of the CAN frames is not ensured (it can be lost)
-* Single CAN frame can be transmitted multiple times
-* CAN frames are delivered in order based on CAN ID priority and never out of
-  order
-* Collision is resolved by avoiding it based on the CAN ID (lower has higher
-  priority)
-* CAN frames correctness is ensured with CRC32
-* Flow control is handled by CAN overload frame
-
-CAN supports few different types of the frames:
-* Data frames: regular frames used to transfer data
-* Remote frames: frame that caries no data and data length (`0x0` - `0xf`) is
-  just informative. SHV RPC uses these as following signal frames:
-  * Message abort frame with data length `0x0`
-  * Device advertisement frame with data length `0x1`
-  * Device discover frame with data length `0x2`
-
-CAN bus is designed for control applications but SHV RPC is rather configuration
-and management interface and thus the design here prioritizes fair queueing over
-message delivery deadline guaranties. This is because we expect that SHV RPC
-will overcommit the bus (contrary to common control applications).
-
-CAN bus has limited bandwidth and thus it is not desirable in most cases to emit
-all signals device has (contrary to standard SHV RPC device design). The SHV
-native way to introduce filtering is to use RPC Broker and thus it is highly
-suggested that devices on CAN bus should expose RPC Broker to it.
-
-### CAN ID
-
-CAN ID can be either 29 bits or 11 bits. SHV RPC uses exclusively only 11 bits
-ID.
-
-```
-+-------------+-----------+---------+--------------------+
-| NotLast [1] | First [1] | QoS [1] | Device address [8] |
-+-------------+-----------+---------+--------------------+
-```
-
-* `NotLast` is `0` when no subsequent CAN frame will follow this one and `1`
-  otherwise. This prioritizes message termination on the bus.
-* `First` is `1` when this is initial CAN frame and `0` otherwise. This penalizes
-  start of the new message and thus prefers SHV RPC message finish.
-* `QoS` should be flipped on every SHV RPC message sent. It ensures that devices
-  with high CAN ID (low priority) get chance to transmit their messages. It is
-  allowed that device that is quiet for considerable amount of time to set it to
-  any state (commonly beneficial for that device).
-* `Device address` this must be unique address of the device transmitting CAN
-  frame or bitwise not of it when `QoS` is `1`. The addresses `0x0` and `0xff`
-  are reserved. The bit flipping of the device address based on the `QoS`
-  ensures that high priority CAN IDs in QoS `1` are low priority ones in the QoS
-  `0` and vice versa, thus devices should get somewhat equal chance to transmit
-  their messages.
-
-_Note: The advantage of using only 11 bits is with CAN-FD where initial
-arbitration runs in slower speed and by not using 29 bits it will be shorter and
-thus communication faster._
-
-### First data byte
-
-The first data byte in the CAN frame has special meaning.
-
-For CAN frames with `First` bit set (`1`) in CAN ID the first byte must be
-destination device address. This identifies the device this SHV RPC message is
-intended for. 
-
-For CAN frames with `First` bit unset (`0`) in CAN ID the first byte must be
-sequence number that starts with `0x0` for the second CAN frame (third is `0x1`
-and so on). If sequence number reaches `0xff` then it just simply wraps around
-to `0x0`.
-
-The complete and valid SHV RPC message thus starts with CAN frame with `First`
-set, continues with CAN frames where `First` is not set and `NotLast` is set and
-first data byte is sequence, and terminates by CAN frame where `NotLast` is not
-set. The consistency of the message (that no CAN frame is lost) is ensured with
-counter in first data byte.
-
-Transport error is detected if CAN frame with `First` not set in CAN ID is
-received with byte having number in first data byte out of order (while ignoring
-frames with same number as the last received CAN frame from that specific
-device). Such SHV RPC message is silently dropped and error is ignored as
-subsequent messages can be consistent again without any action.
-
-The message can be terminated by CAN RTR frame (Remote transmission request)
-with both `NotLast` and `First` unset and data length set to `0x0`.
-
-### Connection
-
-Connection between devices is automatically established with first message being
-exchanged. There can be only one connection channel between two devices. To
-disengage it the `ResetSession` message can be sent (that is regular CAN frame
-with `NotLast` not set and `First` set in CAN ID and data containing only byte
-with destination device address and one `00` byte).
-
-### Broadcast
-
-Due to the CAN bus bandwidth limitations it is suggested to expose SHV RPC
-Broker instead of just plain device, but sometimes it is beneficial to not add
-the signal filtering and instead to automatically broadcast signals. Such
-signals are not intended for any specific device and are just submitted on the
-bus with special destination device address `0xff`.
-
-The only allowed SHV RPC message type for destination device address `0xff` is
-[RpcSignal](./rpcmessage.md#rpcsignal). Other message types received with this
-destination device address must be ignored and devices should not send them.
-
-Handling of the broadcast signals is up to the application it receives it.
-SHV RPC Brokers will propagate them further if given device is mounted and
-subscribed.
-
-One concrete example when this is beneficial is for date and time
-synchronization device. Such device can send signals with precise time to let
-other devices to synchronize with it.
-
-### SHV Device discovery
-
-SHV devices on CAN bus must be possible to discover to not only be able to
-dynamically mount them to SHV RPC Broker but also to actively diagnose the CAN
-bus.
-
-Once device is ready to receive messages on CAN bus it should send CAN RTR frame
-(Remote transmission request) with data length set to `0x1` (the CAN ID should
-have `NotLast` not set and `First` set which applies to all CAN RTR frames).
-This ensures that it gets discovered as soon as possible.
-
-Device that wants to perform discovery can send CAN RTR frame (Remote
-transmission request) with data length set to `0x2`. Device that receives this
-CAN frame must respond with CAN RTR frame with data length set to `0x1`.
-
-### Address collision resolution
-
-The standard deployment should prevent address collisions by allocating them for
-the whole bus before deployment, but there is also a use case for on site ad hoc
-connection and in such situation it is unclear what address should be chosen.
-The device should select random unallocated address but that won't prevent
-collision, only minimize them.
-
-All CAN devices (that includes SHV clients) must listen for others using their
-address and must send CAN RTR (Remote transmission request) frame with size set
-to `0x3` when they receive CAN frame they did not send. CAN devices with same
-dynamic address receiving this RTR frame must choose a different one.
-
-The best practice is to choose address from upper range (close to 255) and
-initially send dummy CAN RTR frame with size set to `0xf`. Do this in 200ms
-intervals five times. The communication with other CAN devices can start if no
-CAN RTR frame with size `0x3` is received in the meantime.
-
-### CAN RTR frames index
-
-This is full list of all different CAN RTR frames used in the protocol:
-
-| Data length field | Usage                        |
-|-------------------|------------------------------|
-| 0x0               | SHV message termination      |
-| 0x1               | Device presence announcement |
-| 0x2               | Device discovery request     |
-| 0x3               | Address collision notice     |
-| 0xf               | Dummy frame with no effect   |
+- [Stream transport layers](./rpctransportlayer/stream.md)
+- [CAN Bus](./rpctransportlayer/can.md)

--- a/src/rpctransportlayer/can.md
+++ b/src/rpctransportlayer/can.md
@@ -1,0 +1,167 @@
+## CAN-FD transport layer
+
+| ❗ This document is in DRAFT stage |
+|------------------------------------|
+
+The communication over CAN (Control Area Network) bus. Compared to other
+transport layers that are point-to-point this is bus and thus it must not only
+provide message transfer but also a connection tracking.
+
+CAN has the following abilities:
+* Delivery of the CAN frames is not ensured (it can be lost)
+* Single CAN frame can be transmitted multiple times
+* CAN frames are delivered in order based on CAN ID priority and never out of
+  order
+* Collision is resolved by avoiding it based on the CAN ID (lower has higher
+  priority)
+* CAN frames correctness is ensured with CRC32
+* Flow control is handled by CAN overload frame
+
+CAN supports few different types of the frames:
+* Data frames: regular frames used to transfer data
+* Remote frames: frame that caries no data and data length (`0x0` - `0xf`) is
+  just informative. SHV RPC uses these as following signal frames:
+  * Message abort frame with data length `0x0`
+  * Device advertisement frame with data length `0x1`
+  * Device discover frame with data length `0x2`
+
+CAN bus is designed for control applications but SHV RPC is rather configuration
+and management interface and thus the design here prioritizes fair queueing over
+message delivery deadline guaranties. This is because we expect that SHV RPC
+will overcommit the bus (contrary to common control applications).
+
+CAN bus has limited bandwidth and thus it is not desirable in most cases to emit
+all signals device has (contrary to standard SHV RPC device design). The SHV
+native way to introduce filtering is to use RPC Broker and thus it is highly
+suggested that devices on CAN bus should expose RPC Broker to it.
+##
+### CAN ID
+
+CAN ID can be either 29 bits or 11 bits. SHV RPC uses exclusively only 11 bits
+ID.
+
+```
++-------------+-----------+---------+--------------------+
+| NotLast [1] | First [1] | QoS [1] | Device address [8] |
++-------------+-----------+---------+--------------------+
+```
+
+* `NotLast` is `0` when no subsequent CAN frame will follow this one and `1`
+  otherwise. This prioritizes message termination on the bus.
+* `First` is `1` when this is initial CAN frame and `0` otherwise. This penalizes
+  start of the new message and thus prefers SHV RPC message finish.
+* `QoS` should be flipped on every SHV RPC message sent. It ensures that devices
+  with high CAN ID (low priority) get chance to transmit their messages. It is
+  allowed that device that is quiet for considerable amount of time to set it to
+  any state (commonly beneficial for that device).
+* `Device address` this must be unique address of the device transmitting CAN
+  frame or bitwise not of it when `QoS` is `1`. The addresses `0x0` and `0xff`
+  are reserved. The bit flipping of the device address based on the `QoS`
+  ensures that high priority CAN IDs in QoS `1` are low priority ones in the QoS
+  `0` and vice versa, thus devices should get somewhat equal chance to transmit
+  their messages.
+
+_Note: The advantage of using only 11 bits is with CAN-FD where initial
+arbitration runs in slower speed and by not using 29 bits it will be shorter and
+thus communication faster._
+
+### First data byte
+
+The first data byte in the CAN frame has special meaning.
+
+For CAN frames with `First` bit set (`1`) in CAN ID the first byte must be
+destination device address. This identifies the device this SHV RPC message is
+intended for. 
+
+For CAN frames with `First` bit unset (`0`) in CAN ID the first byte must be
+sequence number that starts with `0x0` for the second CAN frame (third is `0x1`
+and so on). If sequence number reaches `0xff` then it just simply wraps around
+to `0x0`.
+
+The complete and valid SHV RPC message thus starts with CAN frame with `First`
+set, continues with CAN frames where `First` is not set and `NotLast` is set and
+first data byte is sequence, and terminates by CAN frame where `NotLast` is not
+set. The consistency of the message (that no CAN frame is lost) is ensured with
+counter in first data byte.
+
+Transport error is detected if CAN frame with `First` not set in CAN ID is
+received with byte having number in first data byte out of order (while ignoring
+frames with same number as the last received CAN frame from that specific
+device). Such SHV RPC message is silently dropped and error is ignored as
+subsequent messages can be consistent again without any action.
+
+The message can be terminated by CAN RTR frame (Remote transmission request)
+with both `NotLast` and `First` unset and data length set to `0x0`.
+
+### Connection
+
+Connection between devices is automatically established with first message being
+exchanged. There can be only one connection channel between two devices. To
+disengage it the `ResetSession` message can be sent (that is regular CAN frame
+with `NotLast` not set and `First` set in CAN ID and data containing only byte
+with destination device address and one `00` byte).
+
+### Broadcast
+
+Due to the CAN bus bandwidth limitations it is suggested to expose SHV RPC
+Broker instead of just plain device, but sometimes it is beneficial to not add
+the signal filtering and instead to automatically broadcast signals. Such
+signals are not intended for any specific device and are just submitted on the
+bus with special destination device address `0xff`.
+
+The only allowed SHV RPC message type for destination device address `0xff` is
+[RpcSignal](./rpcmessage.md#rpcsignal). Other message types received with this
+destination device address must be ignored and devices should not send them.
+
+Handling of the broadcast signals is up to the application it receives it.
+SHV RPC Brokers will propagate them further if given device is mounted and
+subscribed.
+
+One concrete example when this is beneficial is for date and time
+synchronization device. Such device can send signals with precise time to let
+other devices to synchronize with it.
+
+### SHV Device discovery
+
+SHV devices on CAN bus must be possible to discover to not only be able to
+dynamically mount them to SHV RPC Broker but also to actively diagnose the CAN
+bus.
+
+Once device is ready to receive messages on CAN bus it should send CAN RTR frame
+(Remote transmission request) with data length set to `0x1` (the CAN ID should
+have `NotLast` not set and `First` set which applies to all CAN RTR frames).
+This ensures that it gets discovered as soon as possible.
+
+Device that wants to perform discovery can send CAN RTR frame (Remote
+transmission request) with data length set to `0x2`. Device that receives this
+CAN frame must respond with CAN RTR frame with data length set to `0x1`.
+
+### Address collision resolution
+
+The standard deployment should prevent address collisions by allocating them for
+the whole bus before deployment, but there is also a use case for on site ad hoc
+connection and in such situation it is unclear what address should be chosen.
+The device should select random unallocated address but that won't prevent
+collision, only minimize them.
+
+All CAN devices (that includes SHV clients) must listen for others using their
+address and must send CAN RTR (Remote transmission request) frame with size set
+to `0x3` when they receive CAN frame they did not send. CAN devices with same
+dynamic address receiving this RTR frame must choose a different one.
+
+The best practice is to choose address from upper range (close to 255) and
+initially send dummy CAN RTR frame with size set to `0xf`. Do this in 200ms
+intervals five times. The communication with other CAN devices can start if no
+CAN RTR frame with size `0x3` is received in the meantime.
+
+### CAN RTR frames index
+
+This is full list of all different CAN RTR frames used in the protocol:
+
+| Data length field | Usage                        |
+|-------------------|------------------------------|
+| 0x0               | SHV message termination      |
+| 0x1               | Device presence announcement |
+| 0x2               | Device discovery request     |
+| 0x3               | Address collision notice     |
+| 0xf               | Dummy frame with no effect   |

--- a/src/rpctransportlayer/stream.md
+++ b/src/rpctransportlayer/stream.md
@@ -1,0 +1,79 @@
+# Stream transport layers
+
+Exchange of the data in streams is common abstraction that is provided by most
+of the transport layers (such as TCP/IP). The important operation to support
+streams in SHV RPC is to split stream to distinct messages. For this purpose
+there are two different protocols defined; Block and Serial protocols.
+
+## Block
+
+The communication on bidirectional stream where delivery is ensured and checked.
+The transport layer establishes and maintains point-to-point connection on its
+own.
+
+Message is transmitted in stream as one complete segment where message length is
+sent before data. The receiving side first reads size and thus knows how much
+data it should expect to receive. Message length is encoded as Chainpack
+unsigned integer.
+
+```
++--------+------+
+| length | data |
++--------+------+
+```
+
+The transport error is detected if there is no byte received from other side for
+more than 5 seconds during the message transfer.
+
+Transport errors are handled by an immediate disconnect. It is expected that
+connecting side is able to reestablish connection.
+
+The primary transport layer used with this is TCP/IP, but this also applies to
+Unix sockets or pair of pipes.
+
+
+## Serial
+
+This is communication over data stream with possible on the line errors (such as
+data corruption).
+
+The message data is encapsulated in start and stop byte and on link layers
+without error checking it is also verified with CRC32. The dedicated bytes for
+this are escaped in the message data.
+
+```
++-----+------+-----------+---------+
+| STX | data | ETX / ATX | *CRC32* |
++-----+------+-----------+---------+
+```
+* `STX` start of message `0xA2`
+* `ETX` end of the message `0xA3`
+* `ATX` abort the message `0xA4`
+* `ESC` escape `0xAA`
+  * `STX` in data will be coded as `ESC` `0x02`
+  * `ETX` in data will be coded as `ESC` `0x03`
+  * `ATX` in data will be coded as `ESC` `0x04`
+  * `ESC` in data will be coded as `ESC` `0x0A`
+* data - escaped message data
+* CRC32 - escaped BigEndian CRC32 of `data` (same as used in IEEE 802.3 and
+  [known as plain
+  CRC-32](https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-32-iso-hdlc))
+  only on channels that do not provide data corruption prevention on its own and
+  only after `ETX` (not after `ATX`).
+
+The transport error is detected if there is no byte received from other side for
+more that 5 seconds during the message transfer or when `STX` or `ATX` is
+received before `EXT` or if `CRC32` do not match received data (on channels with
+possible corruption such as RS232 and not TCP/IP).
+
+Transport errors do not have to be handled explicitly because any subsequent
+message can still be consistent. The invalid message should be just dropped.
+
+The primary transport layer is RS232 with hardware flow control, but usage with
+other streams, such as TCP/IP or Unix domain named socket, is also possible.
+
+In some cases the restart of the connection might not be available. That is for
+example when application just doesn't have rights for it or even when such
+restart would not be propagated to the target, for what ever reason. To solve
+this the empty message is reserved (that is message `STX ETX 0x0`). Once client
+receives a valid empty message then it must drop any state it keeps for it.

--- a/src/rpcurl.md
+++ b/src/rpcurl.md
@@ -145,3 +145,34 @@ bit, enabled hardware flow control, disabled software flow control.
 
 This uses serial console or terminal like interface as bidirectional stream
 channel with [Serial transport layer](rpctransportlayer.md#serial).
+
+## WebSocket
+
+```
+scheme = ("ws")
+authority = host [":" port]
+```
+
+The default `host` is `localhost` and `port` is `8755`.
+
+## WebSocket over SSL
+
+```
+scheme = ("wss")
+authority = host [":" port]
+```
+
+The default `host` is `localhost` and `port` is `8766`.
+
+* `ca`: Path to the file with CA certificates used to verify the peer.
+* `cert`: Path to the file with certificate. For clients connecting to the
+  server this is client certificate that is validated by server for access and
+  in some cases can replace password. For server this is certificate clients
+  verify to validate if they are connecting to the correct server.
+* `key`: Path to the file with secret part of the `cert`. This must be specified
+  alongside with `cert`.
+* `crl`: Path to the file with certification revocation list. This is used to
+  invalidate client certificates on the server.
+* `verify`: can be used with either `true` or `false` to control if server
+  should be verified or not. The default, if not specifies, is `true`. Setting
+  `false` forces client to accept any certificate as valid.

--- a/src/rpcurl.md
+++ b/src/rpcurl.md
@@ -40,7 +40,7 @@ authority = host [":" port]
 The default `host` is `localhost` and `port` is `3755`. Any non-empty `path` is
 invalid as it has no meaning in IP.
 
-This uses TCP/IP with [Stream transport layer](rpctransportlayer.md#stream).
+This uses TCP/IP with [Block transport layer](rpctransportlayer.md#stream).
 
 
 ## TCP/IP serial protocol
@@ -82,7 +82,7 @@ The additional supported options are:
   should be verified or not. The default, if not specifies, is `true`. Setting
   `false` forces client to accept any certificate as valid.
 
-This uses TLS TCP/IP with [Stream transport layer](rpctransportlayer.md#stream).
+This uses TLS TCP/IP with [Block transport layer](rpctransportlayer.md#stream).
 
 
 ## TCP/IP serial protocol with SSL
@@ -108,7 +108,7 @@ scheme = "unix"
 There is no default path and thus empty `path` is considered invalid. Any
 non-empty `authority` is also considered as invalid because it has no meaning.
 
-This uses Unix sockets for local interprocess communication with [Stream
+This uses Unix sockets for local interprocess communication with [Block
 transport layer](rpctransportlayer.md#stream).
 
 


### PR DESCRIPTION
This started as few fixes and ended up with new features...

There are three primary additions, let me explain why I am suggesting them:

The addition of websockets to URL should be self-explanatory. It just makes sense to include it.

The RPC RI is something we are indirectly using and comes from shvcli. I ended up tweaking it and now it is all over the not only pyshv but also this documentation. It just makes sense to define it.

The last suggested feature is the bytes exchange node. This comes from the discussion about `RespCallerIds` and tunneling. In BRC I was also tackling issue on how to in some cases tunnel the safety communication over SHV and it is also beneficial for us to have access to NSH. This gives us that. I am not planning on implementing that right now and I am adding it here as draft because it is an idea I had for covering these requirements. They are not essential for us right now. I just wanted to have a clear design for how we can accomplish access to the serial and terminal devices. The original tunneling is more direct approach but requires modifications in the SHV RPC itself to work. This instead uses RPC as it is suppose to be and builds it on top of it.