### PR TITLE
rpcmethods/file: Add MaxSize to stat method

### DIFF
--- a/src/rpcmethods/file.md
+++ b/src/rpcmethods/file.md
@@ -39,13 +39,14 @@ This method provides information about this file. It is required for file nodes.
 
 The result is IMap with these fields:
 
-| Key | Name       | Type             | Description                                                                            |
-|-----|------------|------------------|----------------------------------------------------------------------------------------|
-| 0   | Type       | Int              | Type of the file (at the moment only regular is supported and thus must always be `0`) |
-| 1   | Size       | Int              | Size of the file in bytes                                                              |
-| 2   | PageSize   | Int              | Page size (ideal size and thus alignment for this file efficient access)               |
-| 3   | AccessTime | DateTime \| Null | Optional time of latest data access                                                    |
-| 4   | ModTime    | DateTime \| Null | Optional time of latest data modification                                              |
+| Key | Name       | Type             | Description                                                                                               |
+|-----|------------|------------------|-----------------------------------------------------------------------------------------------------------|
+| 0   | Type       | Int              | Type of the file (at the moment only regular is supported and thus must always be `0`)                    |
+| 1   | Size       | Int              | Size of the file in bytes                                                                                 |
+| 2   | PageSize   | Int              | Page size (ideal size and thus alignment for this file efficient access)                                  |
+| 3   | AccessTime | DateTime \| Null | Optional time of latest data access                                                                       |
+| 4   | ModTime    | DateTime \| Null | Optional time of latest data modification                                                                 |
+| 5   | MaxWrite   | Int \| Null      | Optional maximal size in bytes of a single write that is accepted (this affects `*:write` and `*:append`) |
 
 ```
 => <id:42, method:"stat", path:"test/file">i{}


### PR DESCRIPTION
On platforms with limited memory pool it is hard to implement write operations because in general in SHV it is not clear if message is valid until it is fully received. For that reason implementations must buffer all received data and thus there must be limit on maximum size that can be handled. The caller can't know this limit and thus it would have to be ether tied to the PageSize or it would have to be somehow discovered. This way it is directly discloused.

Notice that this limit is not in any way tied to the PageSize and thus it is absolutely possible that MaxSize is smaller than PageSize as well as other way around.