### PR TITLE
rpcmethods/device: define .device/alerts as optional

### DIFF
--- a/src/rpcmethods/device.md
+++ b/src/rpcmethods/device.md
@@ -106,6 +106,10 @@ Initiate the device's reset. This might not be implemented and in such case
 
 Get the current device's alerts.
 
+The `.device/alerts` node is [property node](./property.md). Its implementation
+is optional and thus if device doesn't raise any alerts then this node should
+not be present.
+
 | Parameter   | Result         |
 |-------------|----------------|
 | Null \| Int | \[i{...},...\] |

--- a/src/rpcmethods/history.md
+++ b/src/rpcmethods/history.md
@@ -212,8 +212,9 @@ range.
 | Null      | [Int, Int, Int] |
 
 This method provides three integers in a list. The first *Int* is the smallest
-valid record ID, the second *Int* is the biggest valid record ID and the third
-*Int* is the keep record span.
+valid record ID, the second *Int* is the biggest valid record ID plus one (to
+allow case when there are no records to be signaled with same value as the first
+record) and the third *Int* is the keep record span.
 
 The keep record span is range of records where all combinations of SHV path,
 signal name and signal's associated method name in the log are present. That is


### PR DESCRIPTION
Not every device has alerts and they were from the start defined as a separate node to make them optional (SHV RPC supports efficient check for node existence and thus we see node as an API point that might not be provided).