### PR TITLE
rpctransportlayer/websockets: Add definition for the websockets

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -21,6 +21,7 @@
 - [RPC Transport layers](./rpctransportlayer.md)
   - [Stream transport layers](./rpctransportlayer/stream.md)
   - [CAN Bus](./rpctransportlayer/can.md)
+  - [WebSockets](./rpctransportlayer/websockets.md)
 - [RPC URL](./rpcurl.md)
 - [Implementations](./implementations.md)
 - [Tools](./tools.md)

--- a/src/rpctransportlayer.md
+++ b/src/rpctransportlayer.md
@@ -34,3 +34,4 @@ message transport layer as required by SHV RPC. This includes the following:
 
 - [Stream transport layers](./rpctransportlayer/stream.md)
 - [CAN Bus](./rpctransportlayer/can.md)
+- [WebSockets](./rpctransportlayer/websockets.md)

--- a/src/rpctransportlayer/websockets.md
+++ b/src/rpctransportlayer/websockets.md
@@ -1,0 +1,16 @@
+# WebSockets
+
+WebSockets are a natural fit for the RPC transport. There is no need to
+establish any additional encoding or protocol layer. The RPC messages are
+directly transmitted as WebSocket messages.
+
+The [WebSocket's
+subprotocol](https://websockets.spec.whatwg.org/#websocket-protocol) `shv3` is
+used to identify SHV RPC.
+
+## Pre-SHV3 WebSockets
+
+Prior to SHV 3.0, WebSockets were used to transmit messages containing
+arbitrarily fragmented bytes [stream with Block protocol](./stream.md#block).
+This can still be supported if subprotocol `shv3` is *not* negotiated during
+the WebSockets handshake.

--- a/src/rpcurl.md
+++ b/src/rpcurl.md
@@ -40,7 +40,7 @@ authority = host [":" port]
 The default `host` is `localhost` and `port` is `3755`. Any non-empty `path` is
 invalid as it has no meaning in IP.
 
-This uses TCP/IP with [Block transport layer](rpctransportlayer.md#stream).
+This uses TCP/IP with [Block transport layer](rpctransportlayer.md#block).
 
 
 ## TCP/IP serial protocol
@@ -82,7 +82,8 @@ The additional supported options are:
   should be verified or not. The default, if not specifies, is `true`. Setting
   `false` forces client to accept any certificate as valid.
 
-This uses TLS TCP/IP with [Block transport layer](rpctransportlayer.md#stream).
+This uses TLS TCP/IP with [Block transport
+layer](rpctransportlayer/stream.md#block).
 
 
 ## TCP/IP serial protocol with SSL
@@ -96,7 +97,8 @@ This is variant of TCP/IP protocol with SSL. It is same except of used transport
 layer. Please refer to the previous section for more info. The only difference
 is the default `port` that is `3766`.
 
-This uses TLS TCP/IP with [Serial transport layer](rpctransportlayer.md#serial).
+This uses TLS TCP/IP with [Serial transport
+layer](rpctransportlayer/stream.md#serial).
 
 
 ## Unix/Local domain socket
@@ -109,7 +111,7 @@ There is no default path and thus empty `path` is considered invalid. Any
 non-empty `authority` is also considered as invalid because it has no meaning.
 
 This uses Unix sockets for local interprocess communication with [Block
-transport layer](rpctransportlayer.md#stream).
+transport layer](rpctransportlayer/stream.md#block).
 
 
 ## Unix/Local domain socket serial protocol
@@ -122,7 +124,7 @@ This is variant of Unix/Local domain socket. It is same except of used transport
 layer. Please refer to the previous section for more info.
 
 This uses Unix sockets for local interprocess communication with [Serial
-transport layer](rpctransportlayer.md#serial).
+transport layer](rpctransportlayer/stream.md#serial).
 
 
 ## Serial / RS232
@@ -144,7 +146,7 @@ configurable and are expected to be: eight bits per word, no parity, single stop
 bit, enabled hardware flow control, disabled software flow control.
 
 This uses serial console or terminal like interface as bidirectional stream
-channel with [Serial transport layer](rpctransportlayer.md#serial).
+channel with [Serial transport layer](rpctransportlayer/stream.md#serial).
 
 ## WebSocket
 
@@ -154,6 +156,8 @@ authority = host [":" port]
 ```
 
 The default `host` is `localhost` and `port` is `8755`.
+
+This uses [WebSockets transport layer](rpctransportlayer/websockets.md)
 
 ## WebSocket over SSL
 
@@ -176,3 +180,5 @@ The default `host` is `localhost` and `port` is `8766`.
 * `verify`: can be used with either `true` or `false` to control if server
   should be verified or not. The default, if not specifies, is `true`. Setting
   `false` forces client to accept any certificate as valid.
+
+This uses [WebSockets transport layer](rpctransportlayer/websockets.md)


### PR DESCRIPTION
This defines websockets in such a way that pre-SHV3 implementations can still coexists with SHV 3.0.