### PR TITLE
rpctypes: remove `|b` from !dir

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.43
+      MDBOOK_VERSION: 0.4.49
       MDBOOK_PAGETOC_VERSION: 0.2.0
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.49
       MDBOOK_PAGETOC_VERSION: 0.2.0
+      MDBOOK_LINKCHECK_VERSION: 0.7.7
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Install mdBook
@@ -39,6 +40,7 @@ jobs:
           rustup update
           cargo install --version '${{env.MDBOOK_VERSION}}' mdbook
           cargo install --version '${{env.MDBOOK_PAGETOC_VERSION}}' mdbook-pagetoc
+          cargo install --version '${{env.MDBOOK_LINKCHECK_VERSION}}' mdbook-linkcheck 
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5.0.0

--- a/book.toml
+++ b/book.toml
@@ -6,6 +6,8 @@ src = "src"
 title = "SHV RPC Documentation"
 
 [preprocessor.pagetoc]
+
 [output.html]
 additional-css = ["theme/pagetoc.css"]
 additional-js  = ["theme/pagetoc.js"]
+[output.linkcheck]

--- a/src/rpcmessage.md
+++ b/src/rpcmessage.md
@@ -31,7 +31,7 @@ Second part of RPC message is `IMap` with following possible keys.
 
 | Key  | Key name   | Description
 | ---: | ---------- | ------------
-| 1    | Params     | Optional method parameters, any [RPC Value](rpcvalue.md) is allowed.
+| 1    | Param      | Optional method parameter, any [RPC Value](rpcvalue.md) is allowed.
 | 2    | Result     | Successful method call result, any [RPC Value](rpcvalue.md) is allowed.
 | 3    | Error      | Method call exception, see [RPC error](#rpc-error) for more details
 | 4    | Delay      | Method call result delay, [Double](rpcvalue.md) is allowed.

--- a/src/rpcmessage.md
+++ b/src/rpcmessage.md
@@ -10,21 +10,21 @@ There are three kinds of RPC messages defined:
 
 RPC message can have meta-data attribute defined.
 
-| Attribute number  | Attribute name       | Type             | Description
-| ----------------: | -------------------- | ---------------- | ------------
-| 1                 | MetaTypeId           | Int              | Always equal to `1` in case of RPC message
-| 2                 | MetaTypeNameSpaceId  | Int              | Always equal to `0` in case of RPC message, may be omitted.
-| 8                 | RequestId            | Int              | Every RPC request must have unique number per client. Matching RPC response will have the same number.
-| 9                 | ShvPath              | String           | Path on which method will be called.
-| 10                | Method/Signal        | String           | Name of called RPC method or raised signal.
-| 11                | CallerIds            | List of Int      | Internal attribute filled by broker in request message to distinguish requests with the same request ID, but issued by different clients.
-| 13                | RevCallerIds         | List of Int      | Reserved for SHV v2 broker compatibility
-| 14                | Access               | String           | Access granted by broker for called `shvPath` and `method` to current user. This should be used only for extra access info and for backward compatibility while `AccessLevel` is prefered instead.
-| 16                | UserId               | String           | ID of user calling RPC method.
-| 17                | AccessLevel          | Int              | Access level user has assigned for request or minimal access level needed to allow signal to be received.
-| 18                | SeqNo                | Int              | Reserved, it will be used in next API version for multi-part messages   <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
-| 19                | Source               | String           | Used for signals to store method name this signal is associated with.
-| 20                | Repeat               | Bool             | Used for signals to informat that signal was emited as a repeat of some older ones (that might not might not have been sent).
+| Attribute number  | Attribute name       | Type               | Description
+| ----------------: | -------------------- | ----------------   | ------------
+| 1                 | MetaTypeId           | Int                | Always equal to `1` in case of RPC message
+| 2                 | MetaTypeNameSpaceId  | Int                | Always equal to `0` in case of RPC message, may be omitted.
+| 8                 | RequestId            | Int                | Every RPC request must have unique number per client. Matching RPC response will have the same number.
+| 9                 | ShvPath              | String             | Path on which method will be called.
+| 10                | Method/Signal        | String             | Name of called RPC method or raised signal.
+| 11                | CallerIds            | List of Int or Int | Internal attribute filled by broker in request message to distinguish requests with the same request ID, but issued by different clients.
+| 13                | RevCallerIds         | List of Int or Int | Reserved for SHV v2 broker compatibility
+| 14                | Access               | String             | Access granted by broker for called `shvPath` and `method` to current user. This should be used only for extra access info and for backward compatibility while `AccessLevel` is prefered instead.
+| 16                | UserId               | String             | ID of user calling RPC method.
+| 17                | AccessLevel          | Int                | Access level user has assigned for request or minimal access level needed to allow signal to be received.
+| 18                | SeqNo                | Int                | Reserved, it will be used in next API version for multi-part messages   <https://github.com/silicon-heaven/libshv/wiki/multipart-messages>
+| 19                | Source               | String             | Used for signals to store method name this signal is associated with.
+| 20                | Repeat               | Bool               | Used for signals to informat that signal was emited as a repeat of some older ones (that might not might not have been sent).
 
 Second part of RPC message is `IMap` with following possible keys.
 

--- a/src/rpcmethods/discovery.md
+++ b/src/rpcmethods/discovery.md
@@ -54,8 +54,7 @@ The method info in *IMap* must contain these fields:
     for compound types (List, Map, IMap) as addition of fields not present in
     the parameter. Non-compound types do not allow items omission and thus this
     flag has no meaning with them. The usage is expected on setters with known
-    associated getter such as in case of [property
-    nodes](./rpcmethods/property.md).
+    associated getter such as in case of [property nodes](./property.md).
 * `3` (*paramType*): defines parameter type for the requests. Type is a *String*
   that must adhere to [type description definition](../rpctypes.md). It can be
   missing or have value *Null* instead of *String* if method takes no parameter

--- a/src/rpctransportlayer/can.md
+++ b/src/rpctransportlayer/can.md
@@ -110,7 +110,7 @@ signals are not intended for any specific device and are just submitted on the
 bus with special destination device address `0xff`.
 
 The only allowed SHV RPC message type for destination device address `0xff` is
-[RpcSignal](./rpcmessage.md#rpcsignal). Other message types received with this
+[RpcSignal](../rpcmessage.md#rpcsignal). Other message types received with this
 destination device address must be ignored and devices should not send them.
 
 Handling of the broadcast signals is up to the application it receives it.

--- a/src/rpctypes.md
+++ b/src/rpctypes.md
@@ -414,13 +414,13 @@ descriptions.
   [`.history/**:getLog` method](./rpcmethods/history.md#historygetlog). Its
   expanded form is:
   ```
-  {t|n:since,t|n:until,i(0,)|n:count,s|n:ri}
+  {t|n:since:1,t|n:until,i(0,)|n:count,s|n:ri}
   ```
 * `!getLogR` is result of
   [`.history/**:getLog` method](./rpcmethods/history.md#historygetlog). Its
   expanded form is:
   ```
-  [i{t:timestamp:1,i(0,)|n:ref,s|n:path,s|n:signal,s|n:source,?:value,s|n:userId,b|n:repeat}]
+  [i{t|n:timestamp:1,i(0,)|n:ref,s|n:path,s|n:signal,s|n:source,?:value,s|n:userId,b|n:repeat}]
   ```
 * `!historyRecords` is result of
   [`.history/**/.records/*:fetch`

--- a/src/rpctypes.md
+++ b/src/rpctypes.md
@@ -372,7 +372,7 @@ descriptions.
 * `!dir` is one of results of [`*:dir` method](./rpcmethods/discovery.md#dir).
   Its expanded form is:
   ```
-  i{s:name:1,u[b:isGetter:1,b:isSetter,b:largeResult,b:notIndempotent,b:userIDRequired,b:isUpdatable]|n:flags,s|n:paramType,s|n:resultType,i(0,63):accessLevel,{s|n}:signals,{?}:extra:63}|b
+  i{s:name:1,u[b:isGetter:1,b:isSetter,b:largeResult,b:notIndempotent,b:userIDRequired,b:isUpdatable]|n:flags,s|n:paramType,s|n:resultType,i(0,63):accessLevel,{s|n}:signals,{?}:extra:63}
   ```
 * `!alert` is result of [`.device/alerts:get`
   method](./rpcmethods/device.md#devicealertsget) and value of

--- a/src/shvrpcconcepts.md
+++ b/src/shvrpcconcepts.md
@@ -163,8 +163,8 @@ before Response is received. Based on the implementation it could be hard to
 prevent from starting the call again and thus it is desirable to inform about
 Request retrieval as soon as possible. For this purpose there is a dedicated
 Response that informs about delayed Response. This specific Delay Response
-provides hint about progress of the call and thus can be sent multiple times
-before the Response with either Result or Error is sent. The caller is also
-provided with Abort Request that can be used to abort the running call as well
-as to query for the running call existence. During the all this communication
-the same request ID must be used.
+provides hint about progress of the call and can be sent multiple times before
+the Response with either Result or Error is sent. The caller can also use Abort
+Request that can be used to abort the running call or to query for the running
+call existence. During the all of this communication the same request ID must be
+used.


### PR DESCRIPTION
The `|b` is included in the description of the method and it is better to have it defined that way to make the different calling types explicit and not hiden in this type definition.

By removing this the double definition of boolean is removed and only the definition in the `dir` result is used.