### PR TITLE
.github: ensure deploy is performed only on push to master

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -60,6 +60,7 @@ jobs:
       url: ${{steps.deployment.outputs.page_url}}
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Without this if statement deploy is performed even for merge requests, thus overwriting the docs with every merge request. On the other hand, it might be useful to do the build job on merge request, so just add if statement to deploy instead of disabling the entire workflow for merge requests.