### PR TITLE
rpctransportlayer/can: rework the CAN design

### DIFF
--- a/src/rpctransportlayer.md
+++ b/src/rpctransportlayer.md
@@ -9,6 +9,7 @@ layer that guarantees the following functionalities can be used for SHV RPC:
 * Communication needs to be point-to-point, or transport layer needs to emulate
   that.
 * Messages can be of any size
+* The last byte of a message longer than 8 bytes is not null byte
 
 Exchanged messages have `data` always start with a single byte identifying the
 format of the subsequent bytes in the message (if any):


### PR DESCRIPTION
The original design was problematic from multiple angles.

There as no flow control and thus overloaded peer had no way to control senders and the whole bus would be flooded by traffic that nobody wants.

One peer was able to send one message at a time to one peer. This is problematic in combination with RPC Broker and signal propagation. If there is more than one peer subscribed for the signal the implementation would have to buffer the signal in its full to be able to send it to more than one peer. Now one peer can send one message toward one peer but it can do it towards multiple peers at the same time. In other words the destination is now in every frame and thus different destinations can be interleaved.

The broadcasting was removed in favor of just sharing the CAN Bus with non-SHV traffic. Any functionality (such as time synchronization) that would require broadcasting as it was defined can be easily implemented directly on CAN frames.

With previous design it wasn't clear if new connection can be established between peers or not. Now discovery differentiate between addresses that are only for client access and those that run "server" functionality.

@michallenc @ppisa @fvacek 