### PR TITLE
rpcmethods/discovery: add longExecution flag

### DIFF
--- a/src/rpcmethods/discovery.md
+++ b/src/rpcmethods/discovery.md
@@ -55,6 +55,9 @@ The method info in *IMap* must contain these fields:
     the parameter. Non-compound types do not allow items omission and thus this
     flag has no meaning with them. The usage is expected on setters with known
     associated getter such as in case of [property nodes](./property.md).
+  * `128` (*longExecution*, `1 << 7`): The method execution can be longer than
+    normal request-respond exchange. The caller should avoid opportunistic
+    calls.
 * `3` (*paramType*): defines parameter type for the requests. Type is a *String*
   that must adhere to [type description definition](../rpctypes.md). It can be
   missing or have value *Null* instead of *String* if method takes no parameter


### PR DESCRIPTION
This hints on the possible long execution of the method. This is close to the largeResult flag but a bit different because it doesn't hint that it will block the connection but it hints that result might not be sent right after request is received.