### PR TITLE
rpcmethods/history: add .history/**/.records/*:dateSpan

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.5.3
       MDBOOK_PAGETOC_VERSION: 0.3.0
-      MDBOOK_LINKCHECK_VERSION: --git https://github.com/Michael-F-Bryan/mdbook-linkcheck --rev ed981be6ded11562e604fff290ae4c08f1c419c5
+      MDBOOK_LINKCHECK2_VERSION: 0.12.2
       MDBOOK_OPEN_ON_GH_VERSION: 3.0.0
     steps:
       - uses: actions/checkout@v4.2.2
@@ -44,8 +44,8 @@ jobs:
           cargo install \
             mdbook@${{env.MDBOOK_VERSION}} \
             mdbook-pagetoc@${{env.MDBOOK_PAGETOC_VERSION}} \
+            mdbook-linkcheck2@${{env.MDBOOK_LINKCHECK2_VERSION}} \
             mdbook-open-on-gh@${{env.MDBOOK_OPEN_ON_GH_VERSION}}
-          cargo install ${{env.MDBOOK_LINKCHECK_VERSION}} mdbook-linkcheck
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5.0.0

--- a/book.toml
+++ b/book.toml
@@ -15,4 +15,4 @@ git-branch = "master"
 additional-css = ["theme/pagetoc.css", "theme/open-in.css"]
 additional-js  = ["theme/pagetoc.js"]
 git-repository-url = "https://github.com/silicon-heaven/shv-doc"
-[output.linkcheck]
+[output.linkcheck2]

--- a/src/rpcmethods/history.md
+++ b/src/rpcmethods/history.md
@@ -52,28 +52,29 @@ required.
 
 The parameter is an *IMap* containing the following fields:
 
-| Key | Name  | Type           |                        |
-| --- | ----- | -------------- | ---------------------- |
-| 1   | Since | DateTime\|Null | Defines the starting point for log retrieval. Records with a timestamp exactly matching this value are excluded, allowing seamless continuation from the last retrieved record. *Default:* The time at which the request is received. |
-| 2   | Until | DateTime\|Null | Specifies the end point for log retrieval. Only records with a timestamp within the range `(Since, Until>` will be returned. If `Until` comes before `Since`, the interval becomes `<Until, Since)`. In such cases, logs records are returned in **reverse order** (from newest to oldest). If there are too many log records matching specified interval, the device may return fewer records and stop before reaching `Until` timestamp. To retrieve all logs, send a follow-up request using the timestamp of the last returned record as the new `Since`. *Default:* The time at which the request is received. |
-| 3   | Count | Int\|Null      | Limits the maximum number of records returned. Device can provides number of records it decides on but sometimes it is desirable to lower this limit, for example to single record, and this option allows that. If multiple logs have the same timestamp, all must be included even if this exceeds the limit.  *Default:* Unlimited. The snapshot is returned always complete regardless `Count` value specified. |
-| 4   | Ri    | [RPC Resource Identifier](../rpcri.md)\|Null | Filters the results to include only signals matching specified RI. Filter must be relative to `getLog` shv path. It is strongly recommended to call `getLog` using the most specific path possible instead of relying on the `Ri` field, as access permissions are determined by the request path. Using a shorter path may result in insufficient access rights. *Default:* Null, filter is off. |
+| Key | Name  | Type                                         | Description
+| --- | ----- | --------------                               | ----------------------
+| 1   | Since | DateTime\|Null                               | Defines the starting point for log retrieval. Records with a timestamp exactly matching this value are excluded, allowing seamless continuation from the last retrieved record. *Default:* The time at which the request is received.
+| 2   | Until | DateTime\|Null                               | Specifies the end point for log retrieval. Only records with a timestamp within the range `(Since, Until>` will be returned. If `Until` comes before `Since`, the interval becomes `<Until, Since)`. In such cases, log records are returned in **reverse order** (from newest to oldest). If there are too many log records matching the specified interval, the device may return fewer records and stop before reaching the `Until` timestamp. To retrieve all logs, send a follow-up request using the timestamp of the last returned record as the new `Since`. *Default:* The time at which the request is received.
+| 3   | Count | Int\|Null                                    | Limits the maximum number of records returned. The device can provide number of records it decides on, but sometimes it is desirable to lower this limit, for example, to a single record, and this option allows that. If multiple logs have the same timestamp, all must be included, even if this exceeds the limit.  *Default:* Unlimited. The snapshot is always returned complete regardless of the `Count` value specified.
+| 4   | Ri    | [RPC Resource Identifier](../rpcri.md)\|Null | Filters the results to include only signals matching the specified RI. Filter must be relative to `getLog` shv path. It is strongly recommended to call `getLog` using the most specific path possible instead of relying on the `Ri` field, as access permissions are determined by the request path. Using a shorter path may result in insufficient access rights. *Default:* Null, filter is off.
 
 
-The provided value is list of *IMap*s with following fields:
+The provided a value is list of *IMap*s with the following fields:
 
-| Key | Name      | Type     |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| --- | --------- | -------- | -------------------                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 1   | TimeStamp | DateTime | Timestamp of the record.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| 2   | Ref       | Int      | It provides a way to reference the previous record to use it as the value for `Path`, `Signal` and `Source`. It is *Int* where `0` is record right before this one in the list. The offset must always be to the most closest record that specifies desired values. This simplifies parsing because there is no need to remember every single received record but only the latest unique ones. It is up to the implementation if this is used or not. Simple implementations can choose to generate bigger messages and not use this field at all. |
-| 3   | Path      | String   | SHV path to the node relative to the path `getLog` was called on. *Default:* empty path `""`.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| 4   | Signal    | String   | Signal name. *Default:* `chng`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| 5   | Source    | DateTime | Signal's associated method name.  *Default:* `get`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| 6   | Value     | Any      | Signal's value (parameter).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| 7   | UserId    | String   | `UserId` carried by signal message. *Default:* `null`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| 8   | Repeat    | Bool     | `Repeat` carried by signal message. *Default:* `False`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| 9   | Provisional | Bool     | `True` when this entry comes from a [provisional](#provisional-entries) (a.k.a. dirty) log. *Default:* `False`. |
-| 10  | Inaccurate | Bool    | `True` if the record's timestamp might not be accurate because the record [occured before ambiguity](#inaccurate-timestamp). *Default:* `False`. |
+| Key | Name              | Type           | Description
+| --- | ---------         | --------       | -------------------
+| 1   | TimeStamp         | DateTime       | Timestamp of the record. This is time relative to the current device time or the current time provided in the request.
+| 2   | Ref               | Int            | It provides a way to reference the previous record to use it as the value for `Path`, `Signal`, and `Source`. It is *Int* where `0` is the record right before this one in the list. The offset must always be to the most closest record that specifies desired values. This simplifies parsing because there is no need to remember every single received record, but only the latest unique ones. It is up to the implementation whether this is used or not. Simple implementations can choose to generate bigger messages and not use this field at all.
+| 3   | Path              | String         | SHV path to the node relative to the path `getLog` was called on. *Default:* empty path `""`.
+| 4   | Signal            | String         | Signal name. *Default:* `chng`.
+| 5   | Source            | String         | Signal's associated method name.  *Default:* `get`.
+| 6   | Value             | Any            | Signal's value (parameter).
+| 7   | UserId            | String\|Null   | `UserId` carried by signal message. *Default:* `null`.
+| 8   | Repeat            | Bool           | `Repeat` carried by signal message. *Default:* `false`.
+| 9   | Provisional       | Bool           | `True` when this entry comes from a [provisional](#provisional-entries) (a.k.a. dirty) log. *Default:* `false`.
+| 10  | Inaccurate        | Bool           | `True` if the record's timestamp might not be accurate because the record [occured before ambiguity](#inaccurate-timestamp). *Default:* `false`.
+| 11  | OriginalTimeStamp | DateTime\|Null | Original timestamp of the record. This is the time of the device creating the original log at the time of the log creation. This timestamp can't change if teh current time of the device changes. *Default*: `null`.
 
 The provided records should be sorted according to the `TimeStamp` field `1`
 either in ascending order if `Since` < `Until` or descending order
@@ -201,15 +202,15 @@ Every record is *IMap* with following fields:
     (at log creation time).
   * `3`(*timeJump*) time jump record. This is information that all previous
     recorded times should actually be considered to be with time modification.
-    The time offset is specified in field `60`. Only fields `1`, `9`, and `60`
-    are expected for this record type. This is recorded when time
+    The time offset is specified in field `60`. Only fields `1`, `9`, `60`, and
+    optional `10` are expected for this record type. This is recorded when time
     synchronization causes system clock to jump by more than a second.
   * `4`(*timeAbig*) time ambiguity record. This is information that date and
     time of the new logs has no relevance compared to the previous ones. Any
     subsequent records of type `3` should not be applied to them. This is
     recorded when time jump length can't be determined (backward skip of time
     commonly after boot) and thus time desynchronization is detected. The only
-    fields `1` and `9` are expected for this record type.
+    fields `1`, `9`, and optional `10` are expected for this record type.
 * `1`(*timestamp*): *DateTime* of system when record was created. This depends
   on record type. For normal records this is time of signal retrieval.
 * `2`(*path*): *String* with SHV path to the node relative to the `.history`'s
@@ -231,12 +232,17 @@ Every record is *IMap* with following fields:
   fetch will always provide this record unmodified for this ID. The default if
   not provided is the *id* of previous provided record plus one. The default of
   the first record is the *offset* parameter.
-* `10` (*ref*): *Int* with reference to the previous record with matching
-  *type*, *path*, *signal*, *source*, and *accessLevel* fields. These fields
-  are thus exclusive with this one. This field should be used to reduce the
-  size of the message. The value `0` is the record right before this one in the
-  list, `1` is the one before it and so on. The offset must always be the most
-  closes record that specifies desired values.
+* `10` (*ref*): obsolete variant of *idref*. The difference is that offset is
+  relative to the index of the record in the list. *idref* is preffered instead
+  because it allows referencing records outside of the provided list.
+* `11` (*idref*): *Int* with offset for the *id* to the older matching record.
+  This must always be the closest matching record. For *normal* and *keep*
+  records this is matching combination of *path*, *signal*, *source*, and
+  *accessLevel*. For *timeJump* and *timeAbiq* records, this is the closest older
+  record of either type. The offset is one less and thus `0` is the previous
+  *id* relative to the ID of this record (`id - idref - 1`). The fields *type*,
+  *path*, *signal*, *source*, and *accessLevel* can be left out in case
+  the referenced record is in the same list (same method invocation).
 * `60`(*timeJump*): *Int* with number of seconds of time skip. This is used with
   *type* being `3` (*timeJump*).
 
@@ -244,9 +250,9 @@ Fetch that is outside of the valid record ID range must not provide error.
 
 #### `.history/**/.records/*:span`
 
-| Name   | SHV Path                 | Flags  | Param Type | Result Type                         | Access  |
-|--------|--------------------------|--------|------------|-------------------------------------|---------|
-| `span` | `.history/**/.records/*` | Getter |            | `[i:smallest,i:biggest,i(1,):span]` | Service |
+| Name   | SHV Path                 | Flags  | Param Type | Result Type    | Access  |
+|--------|--------------------------|--------|------------|----------------|---------|
+| `span` | `.history/**/.records/*` | Getter |            | `!historySpan` | Service |
 
 This allows fetch of boundaries for the record IDs and also the keep record
 range.
@@ -261,6 +267,45 @@ signal name and signal's associated method name in the log are present. That is
 achieved by creating keep records that are copy of older ones when no signal for
 them is received for some time. It allows of fetching the full log state without
 going through the whole history.
+
+#### `.history/**/.records/*:dateSpan`
+
+| Name       | SHV Path                 | Flags  | Param Type          | Result Type         | Access  |
+|------------|--------------------------|--------|---------------------|---------------------|---------|
+| `dateSpan` | `.history/**/.records/*` | Getter | `!historyDateSpanP` | `!historyDateSpanR` | Service |
+
+This is an optional method that allows caller to get the boundaries for the
+record IDs based on the provided date and time span. It provides a way for the
+clients to seek logs on the devices that otherwise do not support the `getLog`
+method without having to fetch all logs to fully assemble the time context of
+the logs.
+
+The parameter is an *IMap* containing the following fields:
+
+| Key   | Name   | Type           | Description
+| ----- | ------ | ------         | ------------------------
+| 1     | Since  | DateTime\|Null | The oldest record time to be located. If it is Null, then the oldest record is provided.
+| 2     | Until  | DateTime\|Null | The newest record time to be  located. If it is Null, then the newest record is provided.
+| 3     | Now    | DateTime\|Null | The current time the log should be interpreted against. If it is Null, then the device's current time is used.
+
+Be aware that contrary to the `getLog` method the `Since` must always precede
+`Until`.
+
+The provided value is *List* with the following fields in the sequence:
+
+| Name      | Type     | Description
+| ------    | ------   | -------
+| sinceID   | Int      | ID for the record that is the oldest one but not older than `Since`.
+| untilID   | Int      | ID for the record that is the newest one but not newer than `Until`.
+| untilDate | DateTime | Date and time of the `untilID` record interpreted relative to `Now`.
+
+All date and time is real time relative to the `Now`. The record times are
+interpreted using logic described in [Time management in
+logs](#time-management-in-logs) chapter. The difference between `untilDate`
+and `timestamp` of the untilID record is the time difference to be applied to
+all records up to *timeJump*, or *timeAbiq*, or sinceID record. The time
+modifying records must be considered as described in the time management
+chapter.
 
 ### `.history/**/.files/*`
 

--- a/src/rpcmethods/history.md
+++ b/src/rpcmethods/history.md
@@ -298,6 +298,7 @@ The provided value is *List* with the following fields in the sequence:
 | sinceID   | Int      | ID for the record that is the oldest one but not older than `Since`.
 | untilID   | Int      | ID for the record that is the newest one but not newer than `Until`.
 | untilDate | DateTime | Date and time of the `untilID` record interpreted relative to `Now`.
+| span      | Int      | Keep record span that is described in `.history/**/.records/*:span`. It is provided to reduce need to call both methods in case caller wants to assemble snapshot.
 
 All date and time is real time relative to the `Now`. The record times are
 interpreted using logic described in [Time management in

--- a/src/rpctypes.md
+++ b/src/rpctypes.md
@@ -403,19 +403,19 @@ descriptions.
   [`.history/**:getLog` method](./rpcmethods/history.md#historygetlog). Its
   expanded form is:
   ```
-  {t|n:since:1,t|n:until,i(0,)|n:count,s|n:ri}
+  i{t|n:since:1,t|n:until,i(0,)|n:count,s|n:ri}
   ```
 * `!getLogR` is result of
   [`.history/**:getLog` method](./rpcmethods/history.md#historygetlog). Its
   expanded form is:
   ```
-  [i{t|n:timestamp:1,i(0,)|n:ref,s|n:path,s|n:signal,s|n:source,?:value,s|n:userId,b|n:repeat,b|n:provisional,b|n:inaccurate}]
+  [i{t|n:timestamp:1,i(0,)|n:ref,s|n:path,s|n:signal,s|n:source,?:value,s|n:userId,b|n:repeat,b|n:provisional,b|n:inaccurate,t|n:originalTimestamp}]
   ```
 * `!getSnapshotP` is parameter for
   [`.history/**:getSnapshot` method](./rpcmethods/history.md#historygetsnapshot). Its
   expanded form is:
   ```
-  {t|n:time:1,s|n:ri}
+  i{t|n:time:1,s|n:ri}
   ```
 * `!getSnapshotR` is result of
   [`.history/**:getSnapshot` method](./rpcmethods/history.md#historygetsnapshot). Its
@@ -427,7 +427,7 @@ descriptions.
   [`.history/**:getSnapshot` method](./rpcmethods/history.md#historygetsnapshot). Its
   expanded form is:
   ```
-  {t|n:time:1,s|n:ri}
+  i{t|n:time:1,s|n:ri}
   ```
 * `!getSnapshotR` is result of
   [`.history/**:getSnapshot` method](./rpcmethods/history.md#historygetsnapshot). Its
@@ -440,6 +440,24 @@ descriptions.
   method](./rpcmethods/history.md#historyrecordsfetch). Its expanded form is:
   ```
   [i{i[normal:1,keep,timeJump,timeAbig]:type,t:timestamp,s|n:path,s|n:signal,s|n:source,?:value,i(0,63)|n:accessLevel,s|n:userId,b|n:repeat,i(0,)|n:id,i(0,)|n:ref,i|n:timeJump:60}]
+  ```
+* `!historySpan` is result of
+  [`.history/**/.records/*:span`
+  method](./rpcmethods/history.md#historyrecordsspan). Its expanded form is:
+  ```
+  [i:smallest,i:biggest,i(1,):span]
+  ```
+* `!historyDateSpanP` is parameter of
+  [`.history/**/.records/*:dateSpan`
+  method](./rpcmethods/history.md#historyrecordsdatespan). Its expanded form is:
+  ```
+  i{t|n:since:1,t|n:until,t|n:now}
+  ```
+* `!historyDateSpanR` is result of
+  [`.history/**/.records/*:dateSpan`
+  method](./rpcmethods/history.md#historyrecordsdatespan). Its expanded form is:
+  ```
+  [i:sinceID,i:untilID.t:untilDate]
   ```
 
 ## Grammar representation


### PR DESCRIPTION
This is a modification of records API that allows lookup of the records based on the real time. The advantage is that this can be implemented even by devices that otherwise do not want to implement full blown getLog. It has also advantages in terms of timestamp handling.

This also adds an optional fields OriginalTimeStamp to the getLog result. This provides the same versatility of knowing the original device's time the records provide.